### PR TITLE
Add some data for BlockPos

### DIFF
--- a/data/classes/a.json
+++ b/data/classes/a.json
@@ -65,11 +65,7 @@
     },
     {
       "name": "<init>",
-      "descriptor": "(La;)V"
-    },
-    {
-      "name": "<init>",
-      "descriptor": "(Lb;)V",
+      "descriptor": "(La;)V",
       "javadoc": [
         "Copy constructor for this class."
       ],
@@ -80,6 +76,10 @@
           "javadoc": "The instance to copy from"
         }
       ]
+    },
+    {
+      "name": "<init>",
+      "descriptor": "(Lb;)V"
     },
     {
       "name": "<init>",

--- a/data/classes/a.json
+++ b/data/classes/a.json
@@ -69,7 +69,17 @@
     },
     {
       "name": "<init>",
-      "descriptor": "(Lb;)V"
+      "descriptor": "(Lb;)V",
+      "javadoc": [
+        "Copy constructor for this class."
+      ],
+      "parameters": [
+        {
+          "index": 1,
+          "name": "pOther",
+          "javadoc": "The instance to copy from"
+        }
+      ]
     },
     {
       "name": "<init>",

--- a/data/classes/fx.json
+++ b/data/classes/fx.json
@@ -1,9 +1,15 @@
 {
   "name": "fx",
+  "javadoc": [
+    "A position of a block in 3 dimensions."
+  ],
   "fields": [
     {
       "name": "a",
-      "descriptor": "Lcom/mojang/serialization/Codec;"
+      "descriptor": "Lcom/mojang/serialization/Codec;",
+      "javadoc": [
+        "The codec for a {@code BlockPos}."
+      ]
     },
     {
       "name": "b",
@@ -11,7 +17,10 @@
     },
     {
       "name": "e",
-      "descriptor": "Lorg/apache/logging/log4j/Logger;"
+      "descriptor": "Lorg/apache/logging/log4j/Logger;",
+      "javadoc": [
+        "The logger for the class."
+      ]
     },
     {
       "name": "f",
@@ -57,7 +66,27 @@
     },
     {
       "name": "<init>",
-      "descriptor": "(III)V"
+      "descriptor": "(III)V",
+      "javadoc": [
+        "Constructs a {@code BlockPos} using the provided X, Y, and Z coordinates."
+      ],
+      "parameters": [
+        {
+          "index": 1,
+          "name": "pX",
+          "javadoc": "The X coordinate"
+        },
+        {
+          "index": 2,
+          "name": "pY",
+          "javadoc": "The Y coordinate"
+        },
+        {
+          "index": 3,
+          "name": "pZ",
+          "javadoc": "The Z coordinate"
+        }
+      ]
     },
     {
       "name": "<init>",

--- a/data/classes/fx.json
+++ b/data/classes/fx.json
@@ -6,10 +6,7 @@
   "fields": [
     {
       "name": "a",
-      "descriptor": "Lcom/mojang/serialization/Codec;",
-      "javadoc": [
-        "The codec for a {@code BlockPos}."
-      ]
+      "descriptor": "Lcom/mojang/serialization/Codec;"
     },
     {
       "name": "b",
@@ -17,10 +14,7 @@
     },
     {
       "name": "e",
-      "descriptor": "Lorg/apache/logging/log4j/Logger;",
-      "javadoc": [
-        "The logger for the class."
-      ]
+      "descriptor": "Lorg/apache/logging/log4j/Logger;"
     },
     {
       "name": "f",

--- a/data/packages.json
+++ b/data/packages.json
@@ -1,6 +1,9 @@
 [
   {
-    "name": "com/mojang/blaze3d"
+    "name": "com/mojang/blaze3d",
+    "javadoc": [
+      "Root package for the Blaze3D rendering library."
+    ]
   },
   {
     "name": "com/mojang/blaze3d/audio"
@@ -60,7 +63,10 @@
     "name": "net/minecraft/advancements/critereon"
   },
   {
-    "name": "net/minecraft/client"
+    "name": "net/minecraft/client",
+    "javadoc": [
+      "The client-only classes for Minecraft."
+    ]
   },
   {
     "name": "net/minecraft/client/color/block"


### PR DESCRIPTION
Documents the copy constructor for `Matrix3f` and its parameter, documents the 3-int constructor and the codec and logger fields for `BlockPos`, and adds brief documentation for the `com.mojang.blaze3d` and `net.minecraft.client` packages.