### PR TITLE
Add docs for standards

### DIFF
--- a/docs/review-merge-process.md
+++ b/docs/review-merge-process.md
@@ -4,21 +4,21 @@ This document details the review and merge process for Parchment mappings.
 
 ### Requirements to merge:
 
-- If we have any automatic tests, they all must pass.
-  - Example: A PR may not be merged if the Contributor License Agreement (CLA) is not signed.
-- A PR requires two approving reviews
-  - One approving review is required to be from a Parchment team member.
-- We ask that people don’t review things that they don’t actually have the capability to effectively review (knowledge wise).
-- All external reviewers and suggestions are welcome.
+1. All reviews and suggestions from community members are welcome.
+1. All automatic tests must pass:
+    - The Contributor License Agreement (CLA) must be signed.
+1. A PR requires two approving reviews
+    - One approving review is required to be from a member of the ParchmentMC mapping reviewers team.
+    - The other review can be anyone except the original author.
+    - We ask that people don’t review things that they don’t actually have the capability to effectively review (knowledge wise).
+1. After a PR has been approved, it must wait at least 48 hours for any further comments (or, 24 hours if it is deemed to be only minor changes.)
+1. After the required waiting period, if there are no reviews that are requesting changes from a member of the mapping reviewers team then the PR will be merged.
+1. If, after such waiting period, there are members from the mapping reviewers team requesting changes, then those changes must be adressed before the PR can be merged, or go into the waiting period again.
+1. If a PR is generating conflicting opinions, it may be put to a fixed length comment period, where everone is open to disucss changes to the PR. After the comment period, lasting at most one week, it will be put to a vote between the ParchmentMC mapping reviewers team as to wether it should be merged or not.
+1. Submissions should be substantial, although are not required to have any 'minimum contribution' to be considered
+    - Prefer submitting one PR containing a number of smaller unrelated contributions, than many PRs containing very small contributions.
+    - On the other hand, do not lump together otherwise unrelated PR contributions unless there is a reason to do so (i.e. the unrelated contributions are small and can be easilly extended)
+1. PRs are merged and squashed, linked back to the author.
 
-On Resolving conflicting opinions:
 
-- Any names involving substantial conflicts should be available for public input for some length of time (i.e. a discussion time) before merging. After such time, the PR may be merged if there is:
-  1. A simple majority of Parchment team reviewers
-  2. In the event of a tie, A simple majority of all reviewers
-- Submissions should be substantial, although are not required to have any 'minimum contribution' to be considered
-  - Prefer submitting one PR containing a number of smaller unrelated contributions, than many PRs containing very small contributions.
-  - On the other hand, do not lump together otherwise unrelated PR contributions unless there is a reason to do so (i.e. the unrelated contributions are small and can be easilly extended)
-- Contributions must require a github authentication, to link contributors back to individual contributions.
-- Parchment Team / Reviewers can be free to merge and/or review at any time, based on time.
-- PRs are merged and squashed, linked back to the author.
+Note: the phrase "ParchmentMC mapping reviewers team" refers to the members of [the github team of the same name](https://github.com/orgs/ParchmentMC/teams/mapping-reviewers).

--- a/docs/review-merge-process.md
+++ b/docs/review-merge-process.md
@@ -9,15 +9,16 @@ This document details the review and merge process for Parchment mappings.
 - A PR requires two approving reviews
   - One approving review is required to be from a Parchment team member.
 - We ask that people don’t review things that they don’t actually have the capability to effectively review (knowledge wise).
-- All external reviewers are welcome, but not required.
+- All external reviewers and suggestions are welcome.
 
 On Resolving conflicting opinions:
 
 - Any names involving substantial conflicts should be available for public input for some length of time (i.e. a discussion time) before merging. After such time, the PR may be merged if there is:
   1. A simple majority of Parchment team reviewers
   2. In the event of a tie, A simple majority of all reviewers
-- Submissions should be substantial. (Single line typo fix PRs are discouraged)
-- Omnibus PRs may be made ocassionally to accumulate lots of smaller fixes.
+- Submissions should be substantial, although are not required to have any 'minimum contribution' to be considered
+  - Prefer submitting one PR containing a number of smaller unrelated contributions, than many PRs containing very small contributions.
+  - On the other hand, do not lump together otherwise unrelated PR contributions unless there is a reason to do so (i.e. the unrelated contributions are small and can be easilly extended)
 - Contributions must require a github authentication, to link contributors back to individual contributions.
 - Parchment Team / Reviewers can be free to merge and/or review at any time, based on time.
 - PRs are merged and squashed, linked back to the author.

--- a/docs/review-merge-process.md
+++ b/docs/review-merge-process.md
@@ -1,0 +1,23 @@
+# Mappings Review / Merge Process
+
+This document details the review and merge process for Parchment mappings.
+
+### Requirements to merge:
+
+- If we have any automatic tests, they all must pass.
+  - Example: A PR may not be merged if the Contributor License Agreement (CLA) is not signed.
+- A PR requires two approving reviews
+  - One approving review is required to be from a Parchment team member.
+- We ask that people don’t review things that they don’t actually have the capability to effectively review (knowledge wise).
+- All external reviewers are welcome, but not required.
+
+On Resolving conflicting opinions:
+
+- Any names involving substantial conflicts should be available for public input for some length of time (i.e. a discussion time) before merging. After such time, the PR may be merged if there is:
+  1. A simple majority of Parchment team reviewers
+  2. In the event of a tie, A simple majority of all reviewers
+- Submissions should be substantial. (Single line typo fix PRs are discouraged)
+- Omnibus PRs may be made ocassionally to accumulate lots of smaller fixes.
+- Contributions must require a github authentication, to link contributors back to individual contributions.
+- Parchment Team / Reviewers can be free to merge and/or review at any time, based on time.
+- PRs are merged and squashed, linked back to the author.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -1,0 +1,49 @@
+# Mapping Standards
+
+This document details the standards that all contributions to Parchment mappings must follow.
+
+### Parameter Names
+
+- Use American English for spellings
+  - Example: `color`, not `colour`, `armor`, not `armour`
+- All names should be prefixed with `p`
+  - Example: `pLevel`, `pXPos`
+- Names should make sense without the prefix, and should be valid java identifiers NOT reserved keywords as such:
+  - Example: `pFloat` is NOT valid, as `float` is a reserved keyword.
+  - Example:`pOs` is not a correct use of the prefix, it should be `pPos`
+- Parameter names should be based on current context but otherwise verbose and complete words
+  - Avoid single letters, or abbreviations
+    - Example: `pNorthWest` over `pNW`, `pMatrixStack` over `pMStack`. 
+  - Common abbreviations can be used: `IO` / `NBT`, etc.
+  - Use simple parameter names based off of class names, differentiating when there multiple of same type (using more words, not numbers)
+- Use Lower Camel Case (`lowerCamelCase`)
+- Do not use `$` or `_` in variable names
+- All parameters should match the regex `p[A-Z][A-Za-z0-9]+`.
+  - Example: `pDot`, `pPos`, `pBlockState`
+- Favor using Mojang / Mojmap class names over <1.17 MCP classes. In general, the mojmap name is the de-facto standard (some exceptions may apply).
+  - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
+- Common parameter names can use abbreviations for brevity:
+  - Example: `BlockPos pos, Level level, BlockState state, WorldGenLevel level`
+
+
+A note about lambda parameters: They can, and will conflict with both existing variables, other methods, and other lambdas. Care should be taken to review these, until such a time that an automated and/or testable solution is in place to verify that these cannot conflict.  
+
+### Javadocs
+
+- Prioritization:
+  - Prioritize documenting public APIs over private fields and methods.
+  - Prioritize methods and parameters, important fields, and classes.
+  - Follow the principle of least effort for best payoff!
+- Do not document `package-info.java`.
+- Content:
+  - Fully qualified mojmap class names should be used in javadoc tags such as `@link`.
+    - Example: `{@code net.minecraft.math.BlockPos}` instead of `{@code BlockPos`}
+  - Javadocs should be informative - there is no explicit restrictions as long as it is useful.
+  - Avoid overly simple explanations, or “expected knowledge”:
+    - Example: `getWorld() // Gets the world, @return the world`. This not a useful contribution.
+    - Example: `BlockPos() {} // This is the constructor for the class BlockPos` This is expected knowledge - javadocs should not be used to document Java itself.
+  - You can use the `@return` tag in a javadoc.
+  - Do not use `@param` tags directly in method javadocs, use the parameter javadocs instead.
+  - Do not use `@author` or `@since` tags in javadocs.
+  - Try to avoid overly specific examples or code references as they may go “out of date” in future Minecraft versions.
+  - You may add mod loader specific comments: Javadoc lines prefixed with `@<loader>` will indicate information that is only present on one specific mod loader, and should only be visible / be applied when using said mod loader.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -6,24 +6,24 @@ This document details the standards that all contributions to Parchment mappings
 
 1. Use American English for spellings
     - Example: `color`, not `colour`, `armor`, not `armour`
-2. All names should be prefixed with `p`
+1. All names should be prefixed with `p`
     - Example: `pLevel`, `pXPos`
-3. Names should make sense without the prefix, and should be valid java identifiers NOT reserved keywords as such:
+1. Names should make sense without the prefix, and should be valid java identifiers NOT reserved keywords as such:
     - Example: `pFloat` is NOT valid, as `float` is a reserved keyword.
     - Example: `pOs` is not a correct use of the prefix, it should be `pPos`
-4. Parameter names may be named based on the types, and the context in which they are used. They should be verbose and use complete words - do not omit essential information for brevity's sake.
+1. Parameter names may be named based on the types, and the context in which they are used. They should be verbose and use complete words - do not omit essential information for brevity's sake.
     - Example: `BlockPos pAdjacentPos, BlockPos pCurrentPos`, not `BlockPos pPos1, BlockPos pPos2`
-5. Avoid single letters, or abbreviations.
+1. Avoid single letters, or abbreviations.
     - Example: `pNorthWest` over `pNW`, `pMatrixStack` over `pMStack`. 
     - Exception: common abbreviations can be used: `IO` / `NBT`, etc.
-6. Use Lower Camel Case (`lowerCamelCase`)
-7. Do not use `$` or `_` in variable names
-8. All parameters should match the regex `p[A-Z][A-Za-z0-9]+`.
+    - Exception: common class / parameter names can be shortened: `BlockPos pPos, BlockState pState, WorldGenLevel pLevel`
+1. Use Lower Camel Case (`lowerCamelCase`)
+1. Do not use `$` or `_` in variable names
+1. All parameters should match the regex `p[A-Z][A-Za-z0-9]+`.
     - Example: `pDot`, `pPos`, `pBlockState`
-9. Favor using Mojang / Mojmap class names over <1.17 MCP classes. In general, the mojmap name is the de-facto standard (some exceptions may apply).
+1. Favor using Mojang / Mojmap class names over <1.17 MCP classes to name parameters. In general, the mojmap name is the de-facto standard.
     - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
-10. Common parameter names can use abbreviations for brevity:
-    - Example: `BlockPos pos, BlockState state, WorldGenLevel level`
+    - Exception: If a Mojmap name would otherwise break a previous rule (i.e. `setColour(int)`, which would imply a parameter of `pColour`, is not American English)
 
 
 A note about lambda parameters: They can, and will conflict with both existing variables, other methods, and other lambdas. Care should be taken to review these, until such a time that an automated and/or testable solution is in place to verify that these cannot conflict.  
@@ -40,7 +40,7 @@ Prioritization:
 Content:
 
 1. Fully qualified mojmap class names should be used in javadoc tags such as `@link`.
-    - Example: `{@link net.minecraft.math.BlockPos}` instead of `{@link BlockPos`}
+    - Example: `{@link net.minecraft.math.BlockPos}` instead of `{@link BlockPos}`
 2. Javadocs should be informative - there is no explicit restrictions as long as it is useful.
 3. Avoid overly simple explanations, or “expected knowledge”:
     - Example: `getWorld() // Gets the world, @return the world`. This not a useful contribution.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -4,25 +4,25 @@ This document details the standards that all contributions to Parchment mappings
 
 ### Parameter Names
 
-- Use American English for spellings
+1. Use American English for spellings
   - Example: `color`, not `colour`, `armor`, not `armour`
-- All names should be prefixed with `p`
+2. All names should be prefixed with `p`
   - Example: `pLevel`, `pXPos`
-- Names should make sense without the prefix, and should be valid java identifiers NOT reserved keywords as such:
+3. Names should make sense without the prefix, and should be valid java identifiers NOT reserved keywords as such:
   - Example: `pFloat` is NOT valid, as `float` is a reserved keyword.
   - Example:`pOs` is not a correct use of the prefix, it should be `pPos`
-- Parameter names should be based on current context but otherwise verbose and complete words
+4. Parameter names should be based on current context but otherwise verbose and complete words
   - Avoid single letters, or abbreviations
     - Example: `pNorthWest` over `pNW`, `pMatrixStack` over `pMStack`. 
   - Common abbreviations can be used: `IO` / `NBT`, etc.
   - Use simple parameter names based off of class names, differentiating when there multiple of same type (using more words, not numbers)
-- Use Lower Camel Case (`lowerCamelCase`)
-- Do not use `$` or `_` in variable names
-- All parameters should match the regex `p[A-Z][A-Za-z0-9]+`.
+5. Use Lower Camel Case (`lowerCamelCase`)
+6. Do not use `$` or `_` in variable names
+7. All parameters should match the regex `p[A-Z][A-Za-z0-9]+`.
   - Example: `pDot`, `pPos`, `pBlockState`
-- Favor using Mojang / Mojmap class names over <1.17 MCP classes. In general, the mojmap name is the de-facto standard (some exceptions may apply).
+8. Favor using Mojang / Mojmap class names over <1.17 MCP classes. In general, the mojmap name is the de-facto standard (some exceptions may apply).
   - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
-- Common parameter names can use abbreviations for brevity:
+9. Common parameter names can use abbreviations for brevity:
   - Example: `BlockPos pos, Level level, BlockState state, WorldGenLevel level`
 
 
@@ -30,20 +30,23 @@ A note about lambda parameters: They can, and will conflict with both existing v
 
 ### Javadocs
 
-- Prioritization:
-  - Prioritize documenting public APIs over private fields and methods.
-  - Prioritize methods and parameters, important fields, and classes.
-  - Follow the principle of least effort for best payoff!
+Prioritization:
+
+- Prioritize documenting public APIs over private fields and methods.
+- Prioritize methods and parameters, important fields, and classes.
+- Follow the principle of least effort for best payoff!
 - Do not document `package-info.java`.
-- Content:
-  - Fully qualified mojmap class names should be used in javadoc tags such as `@link`.
-    - Example: `{@code net.minecraft.math.BlockPos}` instead of `{@code BlockPos`}
-  - Javadocs should be informative - there is no explicit restrictions as long as it is useful.
-  - Avoid overly simple explanations, or “expected knowledge”:
-    - Example: `getWorld() // Gets the world, @return the world`. This not a useful contribution.
-    - Example: `BlockPos() {} // This is the constructor for the class BlockPos` This is expected knowledge - javadocs should not be used to document Java itself.
-  - You can use the `@return` tag in a javadoc.
-  - Do not use `@param` tags directly in method javadocs, use the parameter javadocs instead.
-  - Do not use `@author` or `@since` tags in javadocs.
-  - Try to avoid overly specific examples or code references as they may go “out of date” in future Minecraft versions.
-  - You may add mod loader specific comments: Javadoc lines prefixed with `@<loader>` will indicate information that is only present on one specific mod loader, and should only be visible / be applied when using said mod loader.
+
+Content:
+
+1. Fully qualified mojmap class names should be used in javadoc tags such as `@link`.
+  - Example: `{@code net.minecraft.math.BlockPos}` instead of `{@code BlockPos`}
+2. Javadocs should be informative - there is no explicit restrictions as long as it is useful.
+3. Avoid overly simple explanations, or “expected knowledge”:
+  - Example: `getWorld() // Gets the world, @return the world`. This not a useful contribution.
+  - Example: `BlockPos() {} // This is the constructor for the class BlockPos` This is expected knowledge - javadocs should not be used to document Java itself.
+4. You can use the `@return` tag in a javadoc.
+5. Do not use `@param` tags directly in method javadocs, use the parameter javadocs instead.
+6. Do not use `@author` or `@since` tags in javadocs.
+7. Try to avoid overly specific examples or code references as they may go “out of date” in future Minecraft versions.
+8. You may add mod loader specific comments: Javadoc lines prefixed with `@<loader>` will indicate information that is only present on one specific mod loader, and should only be visible / be applied when using said mod loader.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -5,25 +5,25 @@ This document details the standards that all contributions to Parchment mappings
 ### Parameter Names
 
 1. Use American English for spellings
-  - Example: `color`, not `colour`, `armor`, not `armour`
+    - Example: `color`, not `colour`, `armor`, not `armour`
 2. All names should be prefixed with `p`
-  - Example: `pLevel`, `pXPos`
+    - Example: `pLevel`, `pXPos`
 3. Names should make sense without the prefix, and should be valid java identifiers NOT reserved keywords as such:
-  - Example: `pFloat` is NOT valid, as `float` is a reserved keyword.
-  - Example:`pOs` is not a correct use of the prefix, it should be `pPos`
+    - Example: `pFloat` is NOT valid, as `float` is a reserved keyword.
+    - Example:`pOs` is not a correct use of the prefix, it should be `pPos`
 4. Parameter names should be based on current context but otherwise verbose and complete words
-  - Avoid single letters, or abbreviations
+5. Avoid single letters, or abbreviations.
     - Example: `pNorthWest` over `pNW`, `pMatrixStack` over `pMStack`. 
-  - Common abbreviations can be used: `IO` / `NBT`, etc.
-  - Use simple parameter names based off of class names, differentiating when there multiple of same type (using more words, not numbers)
-5. Use Lower Camel Case (`lowerCamelCase`)
-6. Do not use `$` or `_` in variable names
-7. All parameters should match the regex `p[A-Z][A-Za-z0-9]+`.
-  - Example: `pDot`, `pPos`, `pBlockState`
-8. Favor using Mojang / Mojmap class names over <1.17 MCP classes. In general, the mojmap name is the de-facto standard (some exceptions may apply).
-  - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
-9. Common parameter names can use abbreviations for brevity:
-  - Example: `BlockPos pos, Level level, BlockState state, WorldGenLevel level`
+    - Exception: common abbreviations can be used: `IO` / `NBT`, etc.
+6. Use simple parameter names based off of class names, differentiating when there multiple of same type (using more words, not numbers)
+7. Use Lower Camel Case (`lowerCamelCase`)
+8. Do not use `$` or `_` in variable names
+9. All parameters should match the regex `p[A-Z][A-Za-z0-9]+`.
+    - Example: `pDot`, `pPos`, `pBlockState`
+10. Favor using Mojang / Mojmap class names over <1.17 MCP classes. In general, the mojmap name is the de-facto standard (some exceptions may apply).
+    - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
+11. Common parameter names can use abbreviations for brevity:
+    - Example: `BlockPos pos, Level level, BlockState state, WorldGenLevel level`
 
 
 A note about lambda parameters: They can, and will conflict with both existing variables, other methods, and other lambdas. Care should be taken to review these, until such a time that an automated and/or testable solution is in place to verify that these cannot conflict.  
@@ -40,11 +40,11 @@ Prioritization:
 Content:
 
 1. Fully qualified mojmap class names should be used in javadoc tags such as `@link`.
-  - Example: `{@code net.minecraft.math.BlockPos}` instead of `{@code BlockPos`}
+    - Example: `{@code net.minecraft.math.BlockPos}` instead of `{@code BlockPos`}
 2. Javadocs should be informative - there is no explicit restrictions as long as it is useful.
 3. Avoid overly simple explanations, or “expected knowledge”:
-  - Example: `getWorld() // Gets the world, @return the world`. This not a useful contribution.
-  - Example: `BlockPos() {} // This is the constructor for the class BlockPos` This is expected knowledge - javadocs should not be used to document Java itself.
+    - Example: `getWorld() // Gets the world, @return the world`. This not a useful contribution.
+    - Example: `BlockPos() {} // This is the constructor for the class BlockPos` This is expected knowledge - javadocs should not be used to document Java itself.
 4. You can use the `@return` tag in a javadoc.
 5. Do not use `@param` tags directly in method javadocs, use the parameter javadocs instead.
 6. Do not use `@author` or `@since` tags in javadocs.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -23,7 +23,7 @@ This document details the standards that all contributions to Parchment mappings
 9. Favor using Mojang / Mojmap class names over <1.17 MCP classes. In general, the mojmap name is the de-facto standard (some exceptions may apply).
     - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
 10. Common parameter names can use abbreviations for brevity:
-    - Example: `BlockPos pos, Level level, BlockState state, WorldGenLevel level`
+    - Example: `BlockPos pos, BlockState state, WorldGenLevel level`
 
 
 A note about lambda parameters: They can, and will conflict with both existing variables, other methods, and other lambdas. Care should be taken to review these, until such a time that an automated and/or testable solution is in place to verify that these cannot conflict.  
@@ -40,7 +40,7 @@ Prioritization:
 Content:
 
 1. Fully qualified mojmap class names should be used in javadoc tags such as `@link`.
-    - Example: `{@code net.minecraft.math.BlockPos}` instead of `{@code BlockPos`}
+    - Example: `{@link net.minecraft.math.BlockPos}` instead of `{@link BlockPos`}
 2. Javadocs should be informative - there is no explicit restrictions as long as it is useful.
 3. Avoid overly simple explanations, or “expected knowledge”:
     - Example: `getWorld() // Gets the world, @return the world`. This not a useful contribution.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -10,19 +10,19 @@ This document details the standards that all contributions to Parchment mappings
     - Example: `pLevel`, `pXPos`
 3. Names should make sense without the prefix, and should be valid java identifiers NOT reserved keywords as such:
     - Example: `pFloat` is NOT valid, as `float` is a reserved keyword.
-    - Example:`pOs` is not a correct use of the prefix, it should be `pPos`
-4. Parameter names should be based on current context but otherwise verbose and complete words
+    - Example: `pOs` is not a correct use of the prefix, it should be `pPos`
+4. Parameter names may be named based on the types, and the context in which they are used. They should be verbose and use complete words - do not omit essential information for brevity's sake.
+    - Example: `BlockPos pAdjacentPos, BlockPos pCurrentPos`, not `BlockPos pPos1, BlockPos pPos2`
 5. Avoid single letters, or abbreviations.
     - Example: `pNorthWest` over `pNW`, `pMatrixStack` over `pMStack`. 
     - Exception: common abbreviations can be used: `IO` / `NBT`, etc.
-6. Use simple parameter names based off of class names, differentiating when there multiple of same type (using more words, not numbers)
-7. Use Lower Camel Case (`lowerCamelCase`)
-8. Do not use `$` or `_` in variable names
-9. All parameters should match the regex `p[A-Z][A-Za-z0-9]+`.
+6. Use Lower Camel Case (`lowerCamelCase`)
+7. Do not use `$` or `_` in variable names
+8. All parameters should match the regex `p[A-Z][A-Za-z0-9]+`.
     - Example: `pDot`, `pPos`, `pBlockState`
-10. Favor using Mojang / Mojmap class names over <1.17 MCP classes. In general, the mojmap name is the de-facto standard (some exceptions may apply).
+9. Favor using Mojang / Mojmap class names over <1.17 MCP classes. In general, the mojmap name is the de-facto standard (some exceptions may apply).
     - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
-11. Common parameter names can use abbreviations for brevity:
+10. Common parameter names can use abbreviations for brevity:
     - Example: `BlockPos pos, Level level, BlockState state, WorldGenLevel level`
 
 

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -17,11 +17,13 @@ This document details the standards that all contributions to Parchment mappings
     - Example: `pNorthWest` over `pNW`, `pMatrixStack` over `pMStack`. 
     - Exception: common abbreviations can be used: `IO` / `NBT`, etc.
     - Exception: common class / parameter names can be shortened: `BlockPos pPos, BlockState pState, WorldGenLevel pLevel`
-1. Use Lower Camel Case (`lowerCamelCase`)
-1. Do not use `$` or `_` in variable names
-1. All parameters should match the regex `p[A-Z][A-Za-z0-9]+`.
+1. Use Lower Camel Case, treating the `p` prefix as the first word.
+    - Example: `pLowerCamelCase`
+3. Do not use `$` or `_` in variable names
+4. All parameters should match the regex `p[A-Z][A-Za-z0-9]*`.
+    - Simply, parameters should contain only alphanumeric characters, and start with the `p` prefix, followed by a capital letter.
     - Example: `pDot`, `pPos`, `pBlockState`
-1. Favor using Mojang / Mojmap class names over <1.17 MCP classes to name parameters. In general, the mojmap name is the de-facto standard.
+5. Favor using Mojang / Mojmap class names over <1.17 MCP classes to name parameters. In general, the mojmap name is the de-facto standard.
     - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
     - Exception: If a Mojmap name would otherwise break a previous rule (i.e. `setColour(int)`, which would imply a parameter of `pColour`, is not American English)
 
@@ -39,7 +41,7 @@ Prioritization:
 
 Content:
 
-1. Fully qualified mojmap class names should be used in javadoc tags such as `@link`.
+1. Fully qualified mojmap class names should be used in javadoc tags that resolve their content, aka `@link` and `@see`.
     - Example: `{@link net.minecraft.math.BlockPos}` instead of `{@link BlockPos}`
 2. Javadocs should be informative - there is no explicit restrictions as long as it is useful.
 3. Avoid overly simple explanations, or “expected knowledge”:
@@ -49,4 +51,3 @@ Content:
 5. Do not use `@param` tags directly in method javadocs, use the parameter javadocs instead.
 6. Do not use `@author` or `@since` tags in javadocs.
 7. Try to avoid overly specific examples or code references as they may go “out of date” in future Minecraft versions.
-8. You may add mod loader specific comments: Javadoc lines prefixed with `@<loader>` will indicate information that is only present on one specific mod loader, and should only be visible / be applied when using said mod loader.


### PR DESCRIPTION
Wrote the standards into two separate documents:

- [Rendered View](https://github.com/alcatrazEscapee/mappings-testing/blob/main/docs/standards.md) `standards.md` wraps the Parameter name / javadoc sections from the temp. working doc. Some minor wording was changed to target the document towards the audience of "people who want to submit mappings"
- [Rendered View](https://github.com/alcatrazEscapee/mappings-testing/blob/main/docs/review-merge-process.md) `review-merge-process.md` wraps the "Review / Merge process" from the temp working doc. (*real.. real shocker that one*). It's intended as a codification of the review and merge standards and procedures the team will adhere to and is worded as such.

I intentionally excluded the "Quality of Life tools" section as that's basically just brainstorming and dreams, and the CLA, because, well, it's already in the CLA bot.