### PR TITLE
Remove All Prefix Information from Documentation

### DIFF
--- a/docs/standards.md
+++ b/docs/standards.md
@@ -6,26 +6,23 @@ This document details the standards that all contributions to Parchment mappings
 
 1. Use American English for spellings
     - Example: `color`, not `colour`, `armor`, not `armour`
-1. All names should be prefixed with `p`
-    - Example: `pLevel`, `pXPos`
-1. Names should make sense without the prefix, and should be valid java identifiers NOT reserved keywords as such:
-    - Example: `pFloat` is NOT valid, as `float` is a reserved keyword.
-    - Example: `pOs` is not a correct use of the prefix, it should be `pPos`
+1. Names should make sense and be valid java identifiers NOT reserved keywords as such:
+    - Example: `float` is NOT valid as it is a reserved keyword.
 1. Parameter names may be named based on the types, and the context in which they are used. They should be verbose and use complete words - do not omit essential information for brevity's sake.
-    - Example: `BlockPos pAdjacentPos, BlockPos pCurrentPos`, not `BlockPos pPos1, BlockPos pPos2`
+    - Example: `BlockPos adjacentPos, BlockPos currentPos`, not `BlockPos pos1, BlockPos pos2`
 1. Avoid single letters, or abbreviations.
-    - Example: `pNorthWest` over `pNW`, `pMatrixStack` over `pMStack`. 
+    - Example: `northWest` over `nW`, `matrixStack` over `mStack`. 
     - Exception: common abbreviations can be used: `IO` / `NBT`, etc.
-    - Exception: common class / parameter names can be shortened: `BlockPos pPos, BlockState pState, WorldGenLevel pLevel`
-1. Use Lower Camel Case, treating the `p` prefix as the first word.
-    - Example: `pLowerCamelCase`
+    - Exception: common class / parameter names can be shortened: `BlockPos pos, BlockState state, WorldGenLevel level`
+1. Use Lower Camel Case.
+    - Example: `lowerCamelCase`
 3. Do not use `$` or `_` in variable names
-4. All parameters should match the regex `p[A-Z][A-Za-z0-9]*`.
-    - Simply, parameters should contain only alphanumeric characters, and start with the `p` prefix, followed by a capital letter.
-    - Example: `pDot`, `pPos`, `pBlockState`
+4. All parameters should match the regex `[a-z][A-Za-z0-9]*`.
+    - Simply, parameters should contain only alphanumeric characters and start with a lowercase letter.
+    - Example: `dot`, `pos`, `blockState`
 5. Favor using Mojang / Mojmap class names over <1.17 MCP classes to name parameters. In general, the mojmap name is the de-facto standard.
     - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
-    - Exception: If a Mojmap name would otherwise break a previous rule (i.e. `setColour(int)`, which would imply a parameter of `pColour`, is not American English)
+    - Exception: If a Mojmap name would otherwise break a previous rule (i.e. `setColour(int)`, which would imply a parameter of `colour`, is not American English)
 
 
 A note about lambda parameters: They can, and will conflict with both existing variables, other methods, and other lambdas. Care should be taken to review these, until such a time that an automated and/or testable solution is in place to verify that these cannot conflict.  


### PR DESCRIPTION
Conform with changes specified within #5 for the standards documentation.