### PR TITLE
Add contributing document, reword the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Our mappings system makes use of the following open-source tools and libraries:
 - [Moshi](https://github.com/square/moshi), a modern JSON parsing library.
 
 ## Support
-Want to ask a question? Get help on how to use these mappings? Or tips on contributing to the mappings? Head over to our [public Discord server](https://discord.gg/XXHhhPRUxs)!
+Want to ask a question? Get help on how to use these mappings? Or tips on contributing to the mappings? Head over to our [public Discord server](https://parchmentmc.org/discord.html)!
 
 ## Licensing
 Parchment mappings are released under the terms of the CC0 1.0 Universal (CC0 1.0), see the [`LICENSE.txt`](LICENSE.txt) for the full legal text.

--- a/README.md
+++ b/README.md
@@ -1,35 +1,22 @@
 Parchment Mappings
 ==================
+
 This repository contains all the mappings and data related to making the parchment mappings.
 
+> This is a relatively new project, and we need all the help we can get. Please excuse the lack of documentation in certain areas, they will be filled in and improved over time. Thank you!
+
 ## Contributing
-1) Fork this project
-2) Clone your fork
-3) Create a directory `inputs` and create your staging change files in it.
-4) Run the following gradle tasks in order:
-   1) `createStagingFromInputs`
-   2) `validateStagingData`
-      A note on this task: It will validate your input and tell you if failed to follow any guidelines.
-      Our CI system will also validate that your contributions follow these guidelines. **Any PR made that does not follow the guidelines will not be considered!**
-   3) `promoteStagingToProduction`
-5) Commit the changed files.
-6) Push your commits to your fork.
-7) Create a Pull Request to pull your changes from your Fork into this repository.
-8) Await feedback and process your feedback that comes from the mapping management team.
+See the [`docs/CONTRIBUTING.md` file](docs/CONTRIBUTING.md) for more information.
 
-## Compass & Staging files
-Our mapping system makes use of [Compass](https://github.com/ParchmentMC/Compass).
-This gradle based tool adds different tasks, but is also able to interpret different file formats to change the mappings in this repository.
+## Tools and Libraries
+Our mappings system makes use of the following open-source tools and libraries:
+- [Compass](https://github.com/ParchmentMC/Compass), the Gradle plugin powering the validation and input systems.
+- [Feather](https://github.com/ParchmentMC/Feather), a data object and parsing library used by ParchmentMC projects.
+- [Enigma](https://github.com/FabricMC/enigma), a tool for deobfuscation and mapping of Java bytecode.
+- [Moshi](https://github.com/square/moshi), a modern JSON parsing library.
 
-The files needed to make changes need to be placed in the input directory, and are known as the `Staging Files`.
-These files follow a specific format, which can be found [here](https://github.com/ParchmentMC/Compass/wiki/Simple-Input-Files).
-
-## Documentation improvements
-This is a relatively new project, and we need all the help we can get.
-Since we currently are heavily focused on getting a release out, we need to excuse ourselves for the lack of documentation, it will improve over time.
-
-## Getting help:
-We provide public help in our Discord server, which you join using this [link](https://discord.gg/XXHhhPRUxs).
+## Support
+Want to ask a question? Get help on how to use these mappings? Or tips on contributing to the mappings? Head over to our [public Discord server](https://discord.gg/XXHhhPRUxs)!
 
 ## Licensing
-Parchment Mappings are released under the terms of the CC0 1.0 Universal (CC0 1.0). 
+Parchment mappings are released under the terms of the CC0 1.0 Universal (CC0 1.0), see the [`LICENSE.txt`](LICENSE.txt) for the full legal text.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+Thank you for deciding to contribute to the Parchment mappings! Whether you are writing some explanatory javadocs, naming parameters, or even just correcting typos, we are glad to have you contribute.
+
+## Setup
+
+Setting up the repository for contributing is fairly simple.
+
+### Prerequisites
+
+ - You have an account on [GitHub](https://github.com), and know how to use basic GitHub functions such as Pull Requests.
+ - You have basic knowledge of git (such as what commits are, what branches are), and using it (cloning a repository, pushing, pulling). This guide assumes you are using the terminal/command line for git operations. If you are using a GUI for git, please consult that application's manual/user guide on how to do these operations.
+
+### Steps
+
+1. **Fork the repository.** Forking the repository creates a copy of the repository (your _fork_) at your personal account, where you push your own commits to your branches.
+
+1. **Clone your forked repository locally.** The repository directory can have any name, by default cloning will make a directory with the same name as the repository.
+
+1. **Run Enigma through the `enigma` Gradle task.** [Enigma][enigma] is a mapping interface originally developed by Jeff Martin and now forked and maintained by the FabricMC team.
+
+1. **Name parameters and create javadocs.**
+	- Classes are listed at the top-left section of the interface. Double-click on a class to open it.
+	- To name a parameter, either move the typing cursor to the parameter name and type the name then press <kbd>Enter</kbd>, or right-click the parameter name and select `Rename` from the context menu.
+	- To add javadocs to a class, field, method, or parameter, right-click the name and select `Edit Javadocs` from the context menu.
+	- To save your changes, press <kbd>Ctrl</kbd> + <kbd>S</kbd> or go to `File` > `Save`.
+	- Be mindful of the mapping standards while mapping, documeted in a [separate file][standards].
+
+1. _Recommended:_ Validate your data through the `validateData` Gradle task. This checks for errors in the mapped data, such as mapped/documented synthetic methods. This task is also ran by the CI on every Pull Request.
+
+1. **Open a Pull Request.** The details of the review and merge process are documented in a [separate file][review-and-merge]. See that document for more information on how PRs are reviewed and merged.
+
+[enigma]: https://github.com/FabricMC/enigma
+[standards]: standards.md
+[review-and-merge]: review-merge-process.md


### PR DESCRIPTION
Adds the `docs/CONTRIBUTING.md` document which holds simple instructions on how to start contributing, along with adjusting the README's wording and rearranging it a bit.