### PR TITLE
Project phoenix: n/m/advancements and n/m/advancements/criterion.

### DIFF
--- a/data/net/minecraft/advancements/Advancement.mapping
+++ b/data/net/minecraft/advancements/Advancement.mapping
@@ -4,27 +4,27 @@ CLASS net/minecraft/advancements/Advancement
 		ARG 2 parent
 		ARG 3 display
 		ARG 4 rewards
-		ARG 5 criterion
+		ARG 5 criteria
 		ARG 6 requirements
 	METHOD addChild (Lnet/minecraft/advancements/Advancement;)V
-		COMMENT Add the given {@code Advancement} as a child of this {@code Advancement}.
+		COMMENT Add the provided {@code child} as a child of this advancement.
 		ARG 1 child
 	METHOD deconstruct ()Lnet/minecraft/advancements/Advancement$Builder;
-		COMMENT Deconstructs this advancement into a {@link net.minecraft.advancements.Advancement#Builder}
+		COMMENT Deconstructs this advancement into a {@link net.minecraft.advancements.Advancement#Builder}.
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 other
 	METHOD getChatComponent ()Lnet/minecraft/network/chat/Component;
-		COMMENT @return The {@link net.minecraft.network.chat.Component} that is shown in the chat message sent after this {@code Advancement} is completed.
+		COMMENT @return The {@link net.minecraft.network.chat.Component} that is shown in the chat message sent after this advancement is completed.
 	METHOD getChildren ()Ljava/lang/Iterable;
 		COMMENT @return An iterable through this advancement's children.
 	METHOD getCriteria ()Ljava/util/Map;
-		COMMENT @return A map of criteria required to complete this advancement, in a map from names to {@link net.minecraft.advancements.Criterion}s.
+		COMMENT @return A map of criteria required to complete this advancement. Keys represent the criteria names and values are the {@link net.minecraft.advancements.Criterion} instances.
 	METHOD getDisplay ()Lnet/minecraft/advancements/DisplayInfo;
-		COMMENT @return Display information for this {@code Advancement}, or {@code null} if this advancement is invisible.
+		COMMENT @return Display information for this advancement, or {@code null} if this advancement is invisible.
 	METHOD getId ()Lnet/minecraft/resources/ResourceLocation;
-		COMMENT @return The ID of this {@code Advancement}
+		COMMENT @return The ID of this advancement.
 	METHOD getMaxCriteraRequired ()I
-		COMMENT @return How many requirements this {@code Advancement} has.
+		COMMENT @return How many requirements this advancement has.
 	METHOD getParent ()Lnet/minecraft/advancements/Advancement;
 		COMMENT @return The parent advancement to display in the advancements screen or {@code null} to signify this is a root advancement.
 	METHOD lambda$new$0 (Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/Style;)Lnet/minecraft/network/chat/Style;
@@ -43,10 +43,10 @@ CLASS net/minecraft/advancements/Advancement
 			ARG 1 key
 			ARG 2 criterion
 		METHOD build (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/Advancement;
-			ARG 1 id
+			ARG 1 parentId
 		METHOD canBuild (Ljava/util/function/Function;)Z
 			COMMENT Tries to resolve the parent of this advancement, if possible. Returns true on success.
-			ARG 1 lookup
+			ARG 1 parentLookup
 		METHOD display (Lnet/minecraft/advancements/DisplayInfo;)Lnet/minecraft/advancements/Advancement$Builder;
 			ARG 1 display
 		METHOD display (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/Component;Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/advancements/FrameType;ZZZ)Lnet/minecraft/advancements/Advancement$Builder;

--- a/data/net/minecraft/advancements/Advancement.mapping
+++ b/data/net/minecraft/advancements/Advancement.mapping
@@ -1,49 +1,45 @@
 CLASS net/minecraft/advancements/Advancement
+	METHOD <init> (Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/advancements/Advancement;Lnet/minecraft/advancements/DisplayInfo;Lnet/minecraft/advancements/AdvancementRewards;Ljava/util/Map;[[Ljava/lang/String;)V
+		ARG 1 id
+		ARG 2 parent
+		ARG 3 display
+		ARG 4 rewards
+		ARG 5 criterion
+		ARG 6 requirements
 	METHOD addChild (Lnet/minecraft/advancements/Advancement;)V
 		COMMENT Add the given {@code Advancement} as a child of this {@code Advancement}.
-		COMMENT
-		COMMENT @see #getParent()
-		ARG 1 advancement
+		ARG 1 child
 	METHOD deconstruct ()Lnet/minecraft/advancements/Advancement$Builder;
-		COMMENT Creates a new advancement builder with the data from this advancement
+		COMMENT Deconstructs this advancement into a {@link net.minecraft.advancements.Advancement#Builder}
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 other
 	METHOD getChatComponent ()Lnet/minecraft/network/chat/Component;
-		COMMENT Returns the {@code ITextComponent} that is shown in the chat message sent after this {@code Advancement} is completed.
-		COMMENT
-		COMMENT @return the {@code ITextComponent} that is shown in the chat message sent after this {@code Advancement} is completed. If this {@code Advancement} is {@linkplain #getDisplay() invisible}, then it consists simply of {@link #getId()}. Otherwise, it is the {@linkplain DisplayInfo#getTitle() title} inside square brackets, colored by the {@linkplain net.minecraft.advancements.FrameType#getFormat frame type}, and hovering over it shows the {@linkplain DisplayInfo#getDescription() description}.
+		COMMENT @return The {@link net.minecraft.network.chat.Component} that is shown in the chat message sent after this {@code Advancement} is completed.
 	METHOD getChildren ()Ljava/lang/Iterable;
-		COMMENT Get the children of this {@code Advancement}.
-		COMMENT
-		COMMENT @return an {@code Iterable} of this {@code Advancement}'s children.
-		COMMENT @see #getParent()
+		COMMENT @return An iterable through this advancement's children.
 	METHOD getCriteria ()Ljava/util/Map;
-		COMMENT Get the {@link Criterion Criteria} used to decide the completion of this {@code Advancement}. Each key-value pair consists of a {@code Criterion} and its name.
-		COMMENT
-		COMMENT @return the criteria used to decide the completion of this {@code Advancement}
-		COMMENT @see #getRequirements()
+		COMMENT @return A map of criteria required to complete this advancement, in a map from names to {@link net.minecraft.advancements.Criterion}s.
 	METHOD getDisplay ()Lnet/minecraft/advancements/DisplayInfo;
-		COMMENT Get information that defines this {@code Advancement}'s appearance in GUIs.
-		COMMENT
-		COMMENT @return information that defines this {@code Advancement}'s appearance in GUIs. If {@code null}, signifies an invisible {@code Advancement}.
+		COMMENT @return Display information for this {@code Advancement}, or {@code null} if this advancement is invisible.
 	METHOD getId ()Lnet/minecraft/resources/ResourceLocation;
-		COMMENT Get this {@code Advancement}'s unique identifier.
-		COMMENT
-		COMMENT @return this {@code Advancement}'s unique identifier
+		COMMENT @return The ID of this {@code Advancement}
 	METHOD getMaxCriteraRequired ()I
-		COMMENT Get how many requirements this {@code Advancement} has.
-		COMMENT
-		COMMENT @return {@code this.getRequirements().length}
-		COMMENT @see #getRequirements()
+		COMMENT @return How many requirements this {@code Advancement} has.
 	METHOD getParent ()Lnet/minecraft/advancements/Advancement;
-		COMMENT Get the {@code Advancement} that is this {@code Advancement}'s parent. This determines the tree structure that appears in the {@linkplain GuiScreenAdvancements GUI}.
-		COMMENT
-		COMMENT @return the parent {@code Advancement} of this {@code Advancement}, or {@code null} to signify that this {@code Advancement} is a root with no parent.
+		COMMENT @return The parent advancement to display in the advancements screen or {@code null} to signify this is a root advancement.
+	METHOD lambda$new$0 (Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/Style;)Lnet/minecraft/network/chat/Style;
+		ARG 1 style
 	CLASS Builder
+		METHOD <init> (Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/advancements/DisplayInfo;Lnet/minecraft/advancements/AdvancementRewards;Ljava/util/Map;[[Ljava/lang/String;)V
+			ARG 1 parentId
+			ARG 2 display
+			ARG 3 rewards
+			ARG 4 criteria
+			ARG 5 requirements
 		METHOD addCriterion (Ljava/lang/String;Lnet/minecraft/advancements/Criterion;)Lnet/minecraft/advancements/Advancement$Builder;
-			COMMENT Adds a criterion to the list of criteria
 			ARG 1 key
 			ARG 2 criterion
 		METHOD addCriterion (Ljava/lang/String;Lnet/minecraft/advancements/CriterionTriggerInstance;)Lnet/minecraft/advancements/Advancement$Builder;
-			COMMENT Adds a criterion to the list of criteria
 			ARG 1 key
 			ARG 2 criterion
 		METHOD build (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/Advancement;
@@ -73,15 +69,19 @@ CLASS net/minecraft/advancements/Advancement
 			ARG 8 hidden
 		METHOD fromJson (Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/DeserializationContext;)Lnet/minecraft/advancements/Advancement$Builder;
 			ARG 0 json
-			ARG 1 conditionParser
+			ARG 1 context
 		METHOD fromNetwork (Lnet/minecraft/network/FriendlyByteBuf;)Lnet/minecraft/advancements/Advancement$Builder;
-			ARG 0 buf
+			ARG 0 buffer
+		METHOD lambda$build$0 (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/Advancement;
+			ARG 0 idIn
 		METHOD parent (Lnet/minecraft/advancements/Advancement;)Lnet/minecraft/advancements/Advancement$Builder;
 			ARG 1 parent
 		METHOD parent (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/Advancement$Builder;
 			ARG 1 parentId
 		METHOD requirements (Lnet/minecraft/advancements/RequirementsStrategy;)Lnet/minecraft/advancements/Advancement$Builder;
 			ARG 1 strategy
+		METHOD requirements ([[Ljava/lang/String;)Lnet/minecraft/advancements/Advancement$Builder;
+			ARG 1 requirements
 		METHOD rewards (Lnet/minecraft/advancements/AdvancementRewards$Builder;)Lnet/minecraft/advancements/Advancement$Builder;
 			ARG 1 rewardsBuilder
 		METHOD rewards (Lnet/minecraft/advancements/AdvancementRewards;)Lnet/minecraft/advancements/Advancement$Builder;
@@ -90,4 +90,4 @@ CLASS net/minecraft/advancements/Advancement
 			ARG 1 consumer
 			ARG 2 id
 		METHOD serializeToNetwork (Lnet/minecraft/network/FriendlyByteBuf;)V
-			ARG 1 buf
+			ARG 1 buffer

--- a/data/net/minecraft/advancements/Advancement.mapping
+++ b/data/net/minecraft/advancements/Advancement.mapping
@@ -43,7 +43,7 @@ CLASS net/minecraft/advancements/Advancement
 			ARG 1 key
 			ARG 2 criterion
 		METHOD build (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/Advancement;
-			ARG 1 parentId
+			ARG 1 id
 		METHOD canBuild (Ljava/util/function/Function;)Z
 			COMMENT Tries to resolve the parent of this advancement, if possible. Returns true on success.
 			ARG 1 parentLookup
@@ -73,7 +73,7 @@ CLASS net/minecraft/advancements/Advancement
 		METHOD fromNetwork (Lnet/minecraft/network/FriendlyByteBuf;)Lnet/minecraft/advancements/Advancement$Builder;
 			ARG 0 buffer
 		METHOD lambda$build$0 (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/Advancement;
-			ARG 0 idIn
+			ARG 0 parentId
 		METHOD parent (Lnet/minecraft/advancements/Advancement;)Lnet/minecraft/advancements/Advancement$Builder;
 			ARG 1 parent
 		METHOD parent (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/Advancement$Builder;

--- a/data/net/minecraft/advancements/AdvancementProgress.mapping
+++ b/data/net/minecraft/advancements/AdvancementProgress.mapping
@@ -4,16 +4,16 @@ CLASS net/minecraft/advancements/AdvancementProgress
 	METHOD fromNetwork (Lnet/minecraft/network/FriendlyByteBuf;)Lnet/minecraft/advancements/AdvancementProgress;
 		ARG 0 buffer
 	METHOD getCriterion (Ljava/lang/String;)Lnet/minecraft/advancements/CriterionProgress;
-		ARG 1 criterion
+		ARG 1 criterionName
 	METHOD grantProgress (Ljava/lang/String;)Z
-		ARG 1 criterion
+		ARG 1 criterionName
 	METHOD lambda$serializeToNetwork$1 (Lnet/minecraft/network/FriendlyByteBuf;Lnet/minecraft/advancements/CriterionProgress;)V
 		ARG 0 bufferIn
 		ARG 1 advancementProgress
 	METHOD lambda$update$0 (Ljava/util/Set;Ljava/util/Map$Entry;)Z
 		ARG 1 entry
 	METHOD revokeProgress (Ljava/lang/String;)Z
-		ARG 1 criterion
+		ARG 1 criterionName
 	METHOD serializeToNetwork (Lnet/minecraft/network/FriendlyByteBuf;)V
 		ARG 1 buffer
 	METHOD update (Ljava/util/Map;[[Ljava/lang/String;)V

--- a/data/net/minecraft/advancements/AdvancementProgress.mapping
+++ b/data/net/minecraft/advancements/AdvancementProgress.mapping
@@ -1,10 +1,17 @@
 CLASS net/minecraft/advancements/AdvancementProgress
+	METHOD <init> (Ljava/util/Map;)V
+		ARG 1 criteria
 	METHOD fromNetwork (Lnet/minecraft/network/FriendlyByteBuf;)Lnet/minecraft/advancements/AdvancementProgress;
 		ARG 0 buffer
 	METHOD getCriterion (Ljava/lang/String;)Lnet/minecraft/advancements/CriterionProgress;
 		ARG 1 criterion
 	METHOD grantProgress (Ljava/lang/String;)Z
 		ARG 1 criterion
+	METHOD lambda$serializeToNetwork$1 (Lnet/minecraft/network/FriendlyByteBuf;Lnet/minecraft/advancements/CriterionProgress;)V
+		ARG 0 bufferIn
+		ARG 1 advancementProgress
+	METHOD lambda$update$0 (Ljava/util/Set;Ljava/util/Map$Entry;)Z
+		ARG 1 entry
 	METHOD revokeProgress (Ljava/lang/String;)Z
 		ARG 1 criterion
 	METHOD serializeToNetwork (Lnet/minecraft/network/FriendlyByteBuf;)V
@@ -13,3 +20,12 @@ CLASS net/minecraft/advancements/AdvancementProgress
 		COMMENT Update this AdvancementProgress' criteria and requirements
 		ARG 1 criteria
 		ARG 2 requirements
+	CLASS Serializer
+		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+			ARG 1 json
+			ARG 2 typeOfT
+			ARG 3 context
+		METHOD serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+			ARG 1 src
+			ARG 2 typeOfSrc
+			ARG 3 context

--- a/data/net/minecraft/advancements/AdvancementRewards.mapping
+++ b/data/net/minecraft/advancements/AdvancementRewards.mapping
@@ -8,24 +8,26 @@ CLASS net/minecraft/advancements/AdvancementRewards
 		ARG 0 json
 	METHOD grant (Lnet/minecraft/server/level/ServerPlayer;)V
 		ARG 1 player
+	METHOD lambda$grant$0 (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/commands/CommandFunction;)V
+		ARG 2 commandFunction
 	CLASS Builder
 		METHOD addExperience (I)Lnet/minecraft/advancements/AdvancementRewards$Builder;
 			COMMENT Adds the given amount of experience. (Not a direct setter)
 			ARG 1 experience
 		METHOD addLootTable (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
-			ARG 1 loot
+			ARG 1 lootTableId
 		METHOD addRecipe (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
 			COMMENT Adds the given recipe to the rewards.
-			ARG 1 recipe
+			ARG 1 recipeId
 		METHOD experience (I)Lnet/minecraft/advancements/AdvancementRewards$Builder;
 			COMMENT Creates a new builder with the given amount of experience as a reward
 			ARG 0 experience
 		METHOD function (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
-			ARG 0 function
+			ARG 0 functionId
 		METHOD loot (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
-			ARG 0 loot
+			ARG 0 lootTableId
 		METHOD recipe (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
 			COMMENT Creates a new builder with the given recipe as a reward.
-			ARG 0 recipe
+			ARG 0 recipeId
 		METHOD runs (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
-			ARG 1 function
+			ARG 1 functionId

--- a/data/net/minecraft/advancements/AdvancementRewards.mapping
+++ b/data/net/minecraft/advancements/AdvancementRewards.mapping
@@ -1,4 +1,9 @@
 CLASS net/minecraft/advancements/AdvancementRewards
+	METHOD <init> (I[Lnet/minecraft/resources/ResourceLocation;[Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/commands/CommandFunction$CacheableFunction;)V
+		ARG 1 experience
+		ARG 2 loot
+		ARG 3 recipes
+		ARG 4 function
 	METHOD deserialize (Lcom/google/gson/JsonObject;)Lnet/minecraft/advancements/AdvancementRewards;
 		ARG 0 json
 	METHOD grant (Lnet/minecraft/server/level/ServerPlayer;)V
@@ -7,12 +12,20 @@ CLASS net/minecraft/advancements/AdvancementRewards
 		METHOD addExperience (I)Lnet/minecraft/advancements/AdvancementRewards$Builder;
 			COMMENT Adds the given amount of experience. (Not a direct setter)
 			ARG 1 experience
+		METHOD addLootTable (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
+			ARG 1 loot
 		METHOD addRecipe (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
 			COMMENT Adds the given recipe to the rewards.
 			ARG 1 recipe
 		METHOD experience (I)Lnet/minecraft/advancements/AdvancementRewards$Builder;
 			COMMENT Creates a new builder with the given amount of experience as a reward
 			ARG 0 experience
+		METHOD function (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
+			ARG 0 function
+		METHOD loot (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
+			ARG 0 loot
 		METHOD recipe (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
 			COMMENT Creates a new builder with the given recipe as a reward.
 			ARG 0 recipe
+		METHOD runs (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/AdvancementRewards$Builder;
+			ARG 1 function

--- a/data/net/minecraft/advancements/Criterion.mapping
+++ b/data/net/minecraft/advancements/Criterion.mapping
@@ -1,24 +1,21 @@
 CLASS net/minecraft/advancements/Criterion
+	METHOD <init> (Lnet/minecraft/advancements/CriterionTriggerInstance;)V
+		ARG 1 trigger
 	METHOD criteriaFromJson (Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/DeserializationContext;)Ljava/util/Map;
-		COMMENT Deserializes all criterions defined within a JSON object.
 		ARG 0 json
-		ARG 1 conditionParser
+		ARG 1 context
 	METHOD criteriaFromNetwork (Lnet/minecraft/network/FriendlyByteBuf;)Ljava/util/Map;
-		COMMENT Read criteria from {@code buf}.
-		COMMENT
-		COMMENT @return the read criteria. Each key-value pair consists of a {@code Criterion} and its name.
-		COMMENT @see #serializeToNetwork(Map, PacketBuffer)
-		ARG 0 bus
+		ARG 0 buffer
 	METHOD criterionFromJson (Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/DeserializationContext;)Lnet/minecraft/advancements/Criterion;
 		ARG 0 json
-		ARG 1 conditionParser
+		ARG 1 context
 	METHOD criterionFromNetwork (Lnet/minecraft/network/FriendlyByteBuf;)Lnet/minecraft/advancements/Criterion;
 		ARG 0 buffer
+	METHOD lambda$serializeToNetwork$0 (Lnet/minecraft/network/FriendlyByteBuf;Lnet/minecraft/advancements/Criterion;)V
+		ARG 0 bufferIn
+		ARG 1 criterion
 	METHOD serializeToNetwork (Ljava/util/Map;Lnet/minecraft/network/FriendlyByteBuf;)V
-		COMMENT Write {@code criteria} to {@code buf}.
-		COMMENT
-		COMMENT @see #criteriaFromNetwork(PacketBuffer)
 		ARG 0 criteria
-		ARG 1 buf
+		ARG 1 buffer
 	METHOD serializeToNetwork (Lnet/minecraft/network/FriendlyByteBuf;)V
 		ARG 1 buffer

--- a/data/net/minecraft/advancements/CriterionProgress.mapping
+++ b/data/net/minecraft/advancements/CriterionProgress.mapping
@@ -2,6 +2,6 @@ CLASS net/minecraft/advancements/CriterionProgress
 	METHOD fromJson (Ljava/lang/String;)Lnet/minecraft/advancements/CriterionProgress;
 		ARG 0 dateTime
 	METHOD fromNetwork (Lnet/minecraft/network/FriendlyByteBuf;)Lnet/minecraft/advancements/CriterionProgress;
-		ARG 0 buf
+		ARG 0 buffer
 	METHOD serializeToNetwork (Lnet/minecraft/network/FriendlyByteBuf;)V
-		ARG 1 buf
+		ARG 1 buffer

--- a/data/net/minecraft/advancements/CriterionTrigger.mapping
+++ b/data/net/minecraft/advancements/CriterionTrigger.mapping
@@ -3,13 +3,19 @@ CLASS net/minecraft/advancements/CriterionTrigger
 		ARG 1 playerAdvancements
 		ARG 2 listener
 	METHOD createInstance (Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/DeserializationContext;)Lnet/minecraft/advancements/CriterionTriggerInstance;
-		ARG 1 object
-		ARG 2 conditions
+		ARG 1 json
+		ARG 2 context
 	METHOD removePlayerListener (Lnet/minecraft/server/PlayerAdvancements;Lnet/minecraft/advancements/CriterionTrigger$Listener;)V
 		ARG 1 playerAdvancements
 		ARG 2 listener
 	METHOD removePlayerListeners (Lnet/minecraft/server/PlayerAdvancements;)V
 		ARG 1 playerAdvancements
 	CLASS Listener
+		METHOD <init> (Lnet/minecraft/advancements/CriterionTriggerInstance;Lnet/minecraft/advancements/Advancement;Ljava/lang/String;)V
+			ARG 1 trigger
+			ARG 2 advancement
+			ARG 3 criterion
+		METHOD equals (Ljava/lang/Object;)Z
+			ARG 1 other
 		METHOD run (Lnet/minecraft/server/PlayerAdvancements;)V
 			ARG 1 playerAdvancements

--- a/data/net/minecraft/advancements/CriterionTriggerInstance.mapping
+++ b/data/net/minecraft/advancements/CriterionTriggerInstance.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/advancements/CriterionTriggerInstance
 	METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
-		ARG 1 conditions
+		ARG 1 context

--- a/data/net/minecraft/advancements/DisplayInfo.mapping
+++ b/data/net/minecraft/advancements/DisplayInfo.mapping
@@ -1,13 +1,22 @@
 CLASS net/minecraft/advancements/DisplayInfo
+	METHOD <init> (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/Component;Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/advancements/FrameType;ZZZ)V
+		ARG 1 icon
+		ARG 2 title
+		ARG 3 description
+		ARG 4 background
+		ARG 5 frame
+		ARG 6 showToast
+		ARG 7 announceChat
+		ARG 8 hidden
 	METHOD fromJson (Lcom/google/gson/JsonObject;)Lnet/minecraft/advancements/DisplayInfo;
-		ARG 0 object
+		ARG 0 json
 		ARG 1 context
 	METHOD fromNetwork (Lnet/minecraft/network/FriendlyByteBuf;)Lnet/minecraft/advancements/DisplayInfo;
-		ARG 0 buf
+		ARG 0 buffer
 	METHOD getIcon (Lcom/google/gson/JsonObject;)Lnet/minecraft/world/item/ItemStack;
-		ARG 0 object
+		ARG 0 json
 	METHOD serializeToNetwork (Lnet/minecraft/network/FriendlyByteBuf;)V
-		ARG 1 buf
+		ARG 1 buffer
 	METHOD setLocation (FF)V
 		ARG 1 x
 		ARG 2 y

--- a/data/net/minecraft/advancements/FrameType.mapping
+++ b/data/net/minecraft/advancements/FrameType.mapping
@@ -1,3 +1,7 @@
 CLASS net/minecraft/advancements/FrameType
+	METHOD <init> (Ljava/lang/String;ILjava/lang/String;ILnet/minecraft/ChatFormatting;)V
+		ARG 3 name
+		ARG 4 texture
+		ARG 5 chatColor
 	METHOD byName (Ljava/lang/String;)Lnet/minecraft/advancements/FrameType;
 		ARG 0 name

--- a/data/net/minecraft/advancements/RequirementsStrategy.mapping
+++ b/data/net/minecraft/advancements/RequirementsStrategy.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/advancements/RequirementsStrategy
+	METHOD createRequirements (Ljava/util/Collection;)[[Ljava/lang/String;
+		ARG 1 requirements
+	METHOD lambda$static$0 (Ljava/util/Collection;)[[Ljava/lang/String;
+		ARG 0 requirements
+	METHOD lambda$static$1 (Ljava/util/Collection;)[[Ljava/lang/String;
+		ARG 0 requirements

--- a/data/net/minecraft/advancements/TreeNodePosition.mapping
+++ b/data/net/minecraft/advancements/TreeNodePosition.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/advancements/TreeNodePosition
+	METHOD <init> (Lnet/minecraft/advancements/Advancement;Lnet/minecraft/advancements/TreeNodePosition;Lnet/minecraft/advancements/TreeNodePosition;II)V
+		ARG 1 advancement
+		ARG 2 parent
+		ARG 3 previousSibling
+		ARG 4 childIndex
+		ARG 5 x
 	METHOD addChild (Lnet/minecraft/advancements/Advancement;Lnet/minecraft/advancements/TreeNodePosition;)Lnet/minecraft/advancements/TreeNodePosition;
 		ARG 1 advancement
 		ARG 2 previous

--- a/data/net/minecraft/advancements/critereon/AbstractCriterionTriggerInstance.mapping
+++ b/data/net/minecraft/advancements/critereon/AbstractCriterionTriggerInstance.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/advancements/critereon/AbstractCriterionTriggerInstance
+	METHOD <init> (Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+		ARG 1 criterion
+		ARG 2 player
 	METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 		ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/BeeNestDestroyedTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/BeeNestDestroyedTrigger.mapping
@@ -5,10 +5,26 @@ CLASS net/minecraft/advancements/critereon/BeeNestDestroyedTrigger
 		ARG 3 conditionsParser
 	METHOD deserializeBlock (Lcom/google/gson/JsonObject;)Lnet/minecraft/world/level/block/Block;
 		ARG 0 json
+	METHOD lambda$trigger$1 (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/item/ItemStack;ILnet/minecraft/advancements/critereon/BeeNestDestroyedTrigger$TriggerInstance;)Z
+		ARG 3 instance
+	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/item/ItemStack;I)V
+		ARG 1 player
+		ARG 2 state
+		ARG 3 stack
+		ARG 4 numBees
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/world/level/block/Block;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)V
+			ARG 1 player
+			ARG 2 block
+			ARG 3 item
+			ARG 4 numBees
 		METHOD destroyedBeeNest (Lnet/minecraft/world/level/block/Block;Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)Lnet/minecraft/advancements/critereon/BeeNestDestroyedTrigger$TriggerInstance;
 			ARG 0 block
 			ARG 1 itemConditionBuilder
 			ARG 2 beesContained
+		METHOD matches (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/item/ItemStack;I)Z
+			ARG 1 state
+			ARG 2 item
+			ARG 3 numBees
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/BeeNestDestroyedTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/BeeNestDestroyedTrigger.mapping
@@ -20,11 +20,11 @@ CLASS net/minecraft/advancements/critereon/BeeNestDestroyedTrigger
 			ARG 4 numBees
 		METHOD destroyedBeeNest (Lnet/minecraft/world/level/block/Block;Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)Lnet/minecraft/advancements/critereon/BeeNestDestroyedTrigger$TriggerInstance;
 			ARG 0 block
-			ARG 1 itemConditionBuilder
+			ARG 1 itemPredicateBuilder
 			ARG 2 beesContained
 		METHOD matches (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/item/ItemStack;I)Z
 			ARG 1 state
-			ARG 2 item
+			ARG 2 stack
 			ARG 3 numBees
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/BlockPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/BlockPredicate.mapping
@@ -1,11 +1,22 @@
 CLASS net/minecraft/advancements/critereon/BlockPredicate
+	METHOD <init> (Lnet/minecraft/tags/Tag;Ljava/util/Set;Lnet/minecraft/advancements/critereon/StatePropertiesPredicate;Lnet/minecraft/advancements/critereon/NbtPredicate;)V
+		ARG 1 tag
+		ARG 2 blocks
+		ARG 3 properties
+		ARG 4 nbt
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/BlockPredicate;
 		ARG 0 json
 	METHOD matches (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/core/BlockPos;)Z
 		ARG 1 level
 		ARG 2 pos
 	CLASS Builder
+		METHOD hasNbt (Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/advancements/critereon/BlockPredicate$Builder;
+			ARG 1 nbt
+		METHOD of (Ljava/lang/Iterable;)Lnet/minecraft/advancements/critereon/BlockPredicate$Builder;
+			ARG 1 blocks
 		METHOD of (Lnet/minecraft/tags/Tag;)Lnet/minecraft/advancements/critereon/BlockPredicate$Builder;
 			ARG 1 tag
+		METHOD of ([Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/advancements/critereon/BlockPredicate$Builder;
+			ARG 1 blocks
 		METHOD setProperties (Lnet/minecraft/advancements/critereon/StatePropertiesPredicate;)Lnet/minecraft/advancements/critereon/BlockPredicate$Builder;
 			ARG 1 statePredicate

--- a/data/net/minecraft/advancements/critereon/BlockPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/BlockPredicate.mapping
@@ -19,4 +19,4 @@ CLASS net/minecraft/advancements/critereon/BlockPredicate
 		METHOD of ([Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/advancements/critereon/BlockPredicate$Builder;
 			ARG 1 blocks
 		METHOD setProperties (Lnet/minecraft/advancements/critereon/StatePropertiesPredicate;)Lnet/minecraft/advancements/critereon/BlockPredicate$Builder;
-			ARG 1 statePredicate
+			ARG 1 properties

--- a/data/net/minecraft/advancements/critereon/BredAnimalsTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/BredAnimalsTrigger.mapping
@@ -3,9 +3,16 @@ CLASS net/minecraft/advancements/critereon/BredAnimalsTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/animal/Animal;Lnet/minecraft/world/entity/animal/Animal;Lnet/minecraft/world/entity/AgeableMob;)V
+		ARG 1 player
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+			ARG 2 parent
+			ARG 3 partner
+			ARG 4 child
 		METHOD bredAnimals (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;)Lnet/minecraft/advancements/critereon/BredAnimalsTrigger$TriggerInstance;
-			ARG 0 builder
+			ARG 0 child
 		METHOD bredAnimals (Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/BredAnimalsTrigger$TriggerInstance;
 			ARG 0 parent
 			ARG 1 partner

--- a/data/net/minecraft/advancements/critereon/BredAnimalsTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/BredAnimalsTrigger.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/advancements/critereon/BredAnimalsTrigger
 			ARG 3 partner
 			ARG 4 child
 		METHOD bredAnimals (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;)Lnet/minecraft/advancements/critereon/BredAnimalsTrigger$TriggerInstance;
-			ARG 0 child
+			ARG 0 childBuilder
 		METHOD bredAnimals (Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/BredAnimalsTrigger$TriggerInstance;
 			ARG 0 parent
 			ARG 1 partner

--- a/data/net/minecraft/advancements/critereon/BrewedPotionTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/BrewedPotionTrigger.mapping
@@ -3,10 +3,15 @@ CLASS net/minecraft/advancements/critereon/BrewedPotionTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$1 (Lnet/minecraft/world/item/alchemy/Potion;Lnet/minecraft/advancements/critereon/BrewedPotionTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/alchemy/Potion;)V
 		ARG 1 player
 		ARG 2 potion
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/world/item/alchemy/Potion;)V
+			ARG 1 player
+			ARG 2 potion
 		METHOD matches (Lnet/minecraft/world/item/alchemy/Potion;)Z
 			ARG 1 potion
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;

--- a/data/net/minecraft/advancements/critereon/ChangeDimensionTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/ChangeDimensionTrigger.mapping
@@ -3,13 +3,24 @@ CLASS net/minecraft/advancements/critereon/ChangeDimensionTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/advancements/critereon/ChangeDimensionTrigger$TriggerInstance;)Z
+		ARG 2 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/resources/ResourceKey;)V
 		ARG 1 player
 		ARG 2 fromLevel
 		ARG 3 toLevel
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/resources/ResourceKey;)V
+			ARG 1 player
+			ARG 2 from
+			ARG 3 to
+		METHOD changedDimension (Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/advancements/critereon/ChangeDimensionTrigger$TriggerInstance;
+			ARG 0 from
+			ARG 1 to
+		METHOD changedDimensionFrom (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/advancements/critereon/ChangeDimensionTrigger$TriggerInstance;
+			ARG 0 from
 		METHOD changedDimensionTo (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/advancements/critereon/ChangeDimensionTrigger$TriggerInstance;
-			ARG 0 toLevel
+			ARG 0 to
 		METHOD matches (Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/resources/ResourceKey;)Z
 			ARG 1 fromLevel
 			ARG 2 toLevel

--- a/data/net/minecraft/advancements/critereon/ChanneledLightningTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/ChanneledLightningTrigger.mapping
@@ -7,6 +7,9 @@ CLASS net/minecraft/advancements/critereon/ChanneledLightningTrigger
 		ARG 1 player
 		ARG 2 entityTriggered
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;[Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+			ARG 2 victims
 		METHOD channeledLightning ([Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/ChanneledLightningTrigger$TriggerInstance;
 			ARG 0 victims
 		METHOD matches (Ljava/util/Collection;)Z

--- a/data/net/minecraft/advancements/critereon/ConstructBeaconTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/ConstructBeaconTrigger.mapping
@@ -3,8 +3,18 @@ CLASS net/minecraft/advancements/critereon/ConstructBeaconTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (ILnet/minecraft/advancements/critereon/ConstructBeaconTrigger$TriggerInstance;)Z
+		ARG 1 instance
+	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;I)V
+		ARG 1 player
+		ARG 2 level
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)V
+			ARG 1 player
+			ARG 2 level
 		METHOD constructedBeacon (Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)Lnet/minecraft/advancements/critereon/ConstructBeaconTrigger$TriggerInstance;
 			ARG 0 level
+		METHOD matches (I)Z
+			ARG 1 level
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/ConsumeItemTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/ConsumeItemTrigger.mapping
@@ -3,13 +3,20 @@ CLASS net/minecraft/advancements/critereon/ConsumeItemTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/advancements/critereon/ConsumeItemTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;)V
 		ARG 1 player
 		ARG 2 item
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+			ARG 1 player
+			ARG 2 item
 		METHOD matches (Lnet/minecraft/world/item/ItemStack;)Z
 			ARG 1 item
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions
+		METHOD usedItem (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/ConsumeItemTrigger$TriggerInstance;
+			ARG 0 item
 		METHOD usedItem (Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/advancements/critereon/ConsumeItemTrigger$TriggerInstance;
 			ARG 0 item

--- a/data/net/minecraft/advancements/critereon/CuredZombieVillagerTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/CuredZombieVillagerTrigger.mapping
@@ -3,11 +3,17 @@ CLASS net/minecraft/advancements/critereon/CuredZombieVillagerTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/advancements/critereon/CuredZombieVillagerTrigger$TriggerInstance;)Z
+		ARG 2 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/monster/Zombie;Lnet/minecraft/world/entity/npc/Villager;)V
 		ARG 1 player
 		ARG 2 zombie
 		ARG 3 villager
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+			ARG 2 zombie
+			ARG 3 villager
 		METHOD matches (Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/world/level/storage/loot/LootContext;)Z
 			ARG 1 zombie
 			ARG 2 villager

--- a/data/net/minecraft/advancements/critereon/DamagePredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/DamagePredicate.mapping
@@ -3,15 +3,15 @@ CLASS net/minecraft/advancements/critereon/DamagePredicate
 		ARG 1 dealtDamage
 		ARG 2 takenDamage
 		ARG 3 sourceEntity
-		ARG 4 blcked
+		ARG 4 blocked
 		ARG 5 type
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/DamagePredicate;
 		ARG 0 json
 	METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/damagesource/DamageSource;FFZ)Z
 		ARG 1 player
 		ARG 2 source
-		ARG 3 dealt
-		ARG 4 taken
+		ARG 3 dealtDamage
+		ARG 4 takenDamage
 		ARG 5 blocked
 	CLASS Builder
 		METHOD blocked (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;
@@ -23,6 +23,6 @@ CLASS net/minecraft/advancements/critereon/DamagePredicate
 		METHOD takenDamage (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;
 			ARG 1 takenDamage
 		METHOD type (Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;)Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;
-			ARG 1 damageType
+			ARG 1 typeBuilder
 		METHOD type (Lnet/minecraft/advancements/critereon/DamageSourcePredicate;)Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;
 			ARG 1 type

--- a/data/net/minecraft/advancements/critereon/DamagePredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/DamagePredicate.mapping
@@ -1,6 +1,12 @@
 CLASS net/minecraft/advancements/critereon/DamagePredicate
+	METHOD <init> (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;Lnet/minecraft/advancements/critereon/EntityPredicate;Ljava/lang/Boolean;Lnet/minecraft/advancements/critereon/DamageSourcePredicate;)V
+		ARG 1 dealtDamage
+		ARG 2 takenDamage
+		ARG 3 sourceEntity
+		ARG 4 blcked
+		ARG 5 type
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/DamagePredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/damagesource/DamageSource;FFZ)Z
 		ARG 1 player
 		ARG 2 source
@@ -10,5 +16,13 @@ CLASS net/minecraft/advancements/critereon/DamagePredicate
 	CLASS Builder
 		METHOD blocked (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;
 			ARG 1 blocked
+		METHOD dealtDamage (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;
+			ARG 1 dealtDamage
+		METHOD sourceEntity (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;
+			ARG 1 sourceEntity
+		METHOD takenDamage (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;
+			ARG 1 takenDamage
 		METHOD type (Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;)Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;
 			ARG 1 damageType
+		METHOD type (Lnet/minecraft/advancements/critereon/DamageSourcePredicate;)Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;
+			ARG 1 type

--- a/data/net/minecraft/advancements/critereon/DamageSourcePredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/DamageSourcePredicate.mapping
@@ -12,16 +12,16 @@ CLASS net/minecraft/advancements/critereon/DamageSourcePredicate
 		ARG 10 sourceEntity
 	METHOD addOptionally (Lcom/google/gson/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;)V
 		ARG 1 json
-		ARG 2 name
+		ARG 2 property
 		ARG 3 value
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate;
 		ARG 0 json
 	METHOD getOptionalBoolean (Lcom/google/gson/JsonObject;Ljava/lang/String;)Ljava/lang/Boolean;
 		ARG 0 json
-		ARG 1 name
+		ARG 1 property
 	METHOD matches (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/damagesource/DamageSource;)Z
 		ARG 1 level
-		ARG 2 vector
+		ARG 2 position
 		ARG 3 source
 	METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/damagesource/DamageSource;)Z
 		ARG 1 player

--- a/data/net/minecraft/advancements/critereon/DamageSourcePredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/DamageSourcePredicate.mapping
@@ -1,14 +1,24 @@
 CLASS net/minecraft/advancements/critereon/DamageSourcePredicate
+	METHOD <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate;)V
+		ARG 1 isProjectile
+		ARG 2 isExplosion
+		ARG 3 bypassesArmor
+		ARG 4 bypassesInvulnerability
+		ARG 5 bypassesMagic
+		ARG 6 isFire
+		ARG 7 isMagic
+		ARG 8 isLightning
+		ARG 9 directEntity
+		ARG 10 sourceEntity
 	METHOD addOptionally (Lcom/google/gson/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;)V
-		COMMENT Adds a property if the value is not null.
-		ARG 1 obj
-		ARG 2 key
+		ARG 1 json
+		ARG 2 name
 		ARG 3 value
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD getOptionalBoolean (Lcom/google/gson/JsonObject;Ljava/lang/String;)Ljava/lang/Boolean;
-		ARG 0 object
-		ARG 1 memberName
+		ARG 0 json
+		ARG 1 name
 	METHOD matches (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/damagesource/DamageSource;)Z
 		ARG 1 level
 		ARG 2 vector
@@ -17,9 +27,27 @@ CLASS net/minecraft/advancements/critereon/DamageSourcePredicate
 		ARG 1 player
 		ARG 2 source
 	CLASS Builder
+		METHOD bypassesArmor (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
+			ARG 1 bypassesArmor
+		METHOD bypassesInvulnerability (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
+			ARG 1 bypassesInvulnerability
+		METHOD bypassesMagic (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
+			ARG 1 bypassesMagic
 		METHOD direct (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
 			ARG 1 directEntity
+		METHOD direct (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
+			ARG 1 directEntity
+		METHOD isExplosion (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
+			ARG 1 isExplosion
+		METHOD isFire (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
+			ARG 1 isFire
 		METHOD isLightning (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
 			ARG 1 isLightning
+		METHOD isMagic (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
+			ARG 1 isMagic
 		METHOD isProjectile (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
 			ARG 1 isProjectile
+		METHOD source (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
+			ARG 1 sourceEntity
+		METHOD source (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;
+			ARG 1 sourceEntity

--- a/data/net/minecraft/advancements/critereon/DeserializationContext.mapping
+++ b/data/net/minecraft/advancements/critereon/DeserializationContext.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/advancements/critereon/DeserializationContext
+	METHOD <init> (Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/world/level/storage/loot/PredicateManager;)V
+		ARG 1 id
+		ARG 2 predicateManager
 	METHOD deserializeConditions (Lcom/google/gson/JsonArray;Ljava/lang/String;Lnet/minecraft/world/level/storage/loot/parameters/LootContextParamSet;)[Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition;
 		ARG 1 json
 		ARG 3 parameterSet

--- a/data/net/minecraft/advancements/critereon/DistancePredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/DistancePredicate.mapping
@@ -1,6 +1,16 @@
 CLASS net/minecraft/advancements/critereon/DistancePredicate
+	METHOD <init> (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 horizontal
+		ARG 5 absolute
+	METHOD absolute (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)Lnet/minecraft/advancements/critereon/DistancePredicate;
+		ARG 0 absolute
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/DistancePredicate;
-		ARG 0 element
+		ARG 0 json
+	METHOD horizontal (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)Lnet/minecraft/advancements/critereon/DistancePredicate;
+		ARG 0 horizontal
 	METHOD matches (DDDDDD)Z
 		ARG 1 x1
 		ARG 3 y1
@@ -8,3 +18,5 @@ CLASS net/minecraft/advancements/critereon/DistancePredicate
 		ARG 7 x2
 		ARG 9 y2
 		ARG 11 z2
+	METHOD vertical (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)Lnet/minecraft/advancements/critereon/DistancePredicate;
+		ARG 0 vertical

--- a/data/net/minecraft/advancements/critereon/EffectsChangedTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/EffectsChangedTrigger.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/advancements/critereon/EffectsChangedTrigger
 		ARG 2 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/Entity;)V
 		ARG 1 player
-		ARG 2 entity
+		ARG 2 source
 	CLASS TriggerInstance
 		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/MobEffectsPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
 			ARG 1 player

--- a/data/net/minecraft/advancements/critereon/EffectsChangedTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/EffectsChangedTrigger.mapping
@@ -3,8 +3,22 @@ CLASS net/minecraft/advancements/critereon/EffectsChangedTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/advancements/critereon/EffectsChangedTrigger$TriggerInstance;)Z
+		ARG 2 instance
+	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/Entity;)V
+		ARG 1 player
+		ARG 2 entity
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/MobEffectsPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+			ARG 2 effects
+			ARG 3 source
+		METHOD gotEffectsFrom (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/EffectsChangedTrigger$TriggerInstance;
+			ARG 0 source
 		METHOD hasEffects (Lnet/minecraft/advancements/critereon/MobEffectsPredicate;)Lnet/minecraft/advancements/critereon/EffectsChangedTrigger$TriggerInstance;
 			ARG 0 effects
+		METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/level/storage/loot/LootContext;)Z
+			ARG 1 player
+			ARG 2 lootContext
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/EnchantedItemTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/EnchantedItemTrigger.mapping
@@ -3,11 +3,17 @@ CLASS net/minecraft/advancements/critereon/EnchantedItemTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/item/ItemStack;ILnet/minecraft/advancements/critereon/EnchantedItemTrigger$TriggerInstance;)Z
+		ARG 2 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;I)V
 		ARG 1 player
 		ARG 2 item
 		ARG 3 levelsSpent
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)V
+			ARG 1 player
+			ARG 2 item
+			ARG 3 levels
 		METHOD matches (Lnet/minecraft/world/item/ItemStack;I)Z
 			ARG 1 item
 			ARG 2 levels

--- a/data/net/minecraft/advancements/critereon/EnchantmentPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/EnchantmentPredicate.mapping
@@ -1,7 +1,10 @@
 CLASS net/minecraft/advancements/critereon/EnchantmentPredicate
+	METHOD <init> (Lnet/minecraft/world/item/enchantment/Enchantment;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)V
+		ARG 1 enchantment
+		ARG 2 level
 	METHOD containedIn (Ljava/util/Map;)Z
 		ARG 1 enchantments
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/EnchantmentPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD fromJsonArray (Lcom/google/gson/JsonElement;)[Lnet/minecraft/advancements/critereon/EnchantmentPredicate;
-		ARG 0 element
+		ARG 0 json

--- a/data/net/minecraft/advancements/critereon/EnterBlockTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/EnterBlockTrigger.mapping
@@ -4,11 +4,19 @@ CLASS net/minecraft/advancements/critereon/EnterBlockTrigger
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
 	METHOD deserializeBlock (Lcom/google/gson/JsonObject;)Lnet/minecraft/world/level/block/Block;
-		ARG 0 jsonObject
+		ARG 0 json
+	METHOD lambda$createInstance$0 (Lnet/minecraft/world/level/block/Block;Ljava/lang/String;)V
+		ARG 1 property
+	METHOD lambda$trigger$2 (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/advancements/critereon/EnterBlockTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/level/block/state/BlockState;)V
 		ARG 1 player
 		ARG 2 state
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/world/level/block/Block;Lnet/minecraft/advancements/critereon/StatePropertiesPredicate;)V
+			ARG 1 player
+			ARG 2 block
+			ARG 3 state
 		METHOD entersBlock (Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/advancements/critereon/EnterBlockTrigger$TriggerInstance;
 			ARG 0 block
 		METHOD matches (Lnet/minecraft/world/level/block/state/BlockState;)Z

--- a/data/net/minecraft/advancements/critereon/EntityEquipmentPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/EntityEquipmentPredicate.mapping
@@ -1,14 +1,25 @@
 CLASS net/minecraft/advancements/critereon/EntityEquipmentPredicate
+	METHOD <init> (Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+		ARG 1 head
+		ARG 2 chest
+		ARG 3 legs
+		ARG 4 feet
+		ARG 5 mainhand
+		ARG 6 offhand
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/EntityEquipmentPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD matches (Lnet/minecraft/world/entity/Entity;)Z
 		ARG 1 entity
 	CLASS Builder
 		METHOD chest (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/EntityEquipmentPredicate$Builder;
-			ARG 1 condition
+			ARG 1 chest
 		METHOD feet (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/EntityEquipmentPredicate$Builder;
-			ARG 1 condition
+			ARG 1 feet
 		METHOD head (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/EntityEquipmentPredicate$Builder;
-			ARG 1 condition
+			ARG 1 head
 		METHOD legs (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/EntityEquipmentPredicate$Builder;
-			ARG 1 condition
+			ARG 1 legs
+		METHOD mainhand (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/EntityEquipmentPredicate$Builder;
+			ARG 1 mainhand
+		METHOD offhand (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/EntityEquipmentPredicate$Builder;
+			ARG 1 offhand

--- a/data/net/minecraft/advancements/critereon/EntityFlagsPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/EntityFlagsPredicate.mapping
@@ -1,17 +1,29 @@
 CLASS net/minecraft/advancements/critereon/EntityFlagsPredicate
+	METHOD <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+		ARG 1 isOnFire
+		ARG 2 isCouching
+		ARG 3 isSprinting
+		ARG 4 isSwimming
+		ARG 5 isBaby
 	METHOD addOptionalBoolean (Lcom/google/gson/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;)V
-		ARG 1 jsonObject
+		ARG 1 json
 		ARG 2 name
-		ARG 3 bool
+		ARG 3 value
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/EntityFlagsPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD getOptionalBoolean (Lcom/google/gson/JsonObject;Ljava/lang/String;)Ljava/lang/Boolean;
-		ARG 0 jsonObject
+		ARG 0 json
 		ARG 1 name
 	METHOD matches (Lnet/minecraft/world/entity/Entity;)Z
 		ARG 1 entity
 	CLASS Builder
+		METHOD setCrouching (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/EntityFlagsPredicate$Builder;
+			ARG 1 isCrouching
 		METHOD setIsBaby (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/EntityFlagsPredicate$Builder;
-			ARG 1 baby
+			ARG 1 isBaby
 		METHOD setOnFire (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/EntityFlagsPredicate$Builder;
 			ARG 1 onFire
+		METHOD setSprinting (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/EntityFlagsPredicate$Builder;
+			ARG 1 isSprinting
+		METHOD setSwimming (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/EntityFlagsPredicate$Builder;
+			ARG 1 isSwimming

--- a/data/net/minecraft/advancements/critereon/EntityHurtPlayerTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/EntityHurtPlayerTrigger.mapping
@@ -8,9 +8,9 @@ CLASS net/minecraft/advancements/critereon/EntityHurtPlayerTrigger
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/damagesource/DamageSource;FFZ)V
 		ARG 1 player
 		ARG 2 source
-		ARG 3 amountDealt
-		ARG 4 amountTaken
-		ARG 5 wasBlocked
+		ARG 3 dealtDamage
+		ARG 4 takenDamage
+		ARG 5 blocked
 	CLASS TriggerInstance
 		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/DamagePredicate;)V
 			ARG 1 player
@@ -22,8 +22,8 @@ CLASS net/minecraft/advancements/critereon/EntityHurtPlayerTrigger
 		METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/damagesource/DamageSource;FFZ)Z
 			ARG 1 player
 			ARG 2 source
-			ARG 3 amountDealt
-			ARG 4 amountTaken
-			ARG 5 wasBlocked
+			ARG 3 dealtDamage
+			ARG 4 takenDamage
+			ARG 5 blocked
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/EntityHurtPlayerTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/EntityHurtPlayerTrigger.mapping
@@ -3,6 +3,8 @@ CLASS net/minecraft/advancements/critereon/EntityHurtPlayerTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/damagesource/DamageSource;FFZLnet/minecraft/advancements/critereon/EntityHurtPlayerTrigger$TriggerInstance;)Z
+		ARG 5 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/damagesource/DamageSource;FFZ)V
 		ARG 1 player
 		ARG 2 source
@@ -10,8 +12,13 @@ CLASS net/minecraft/advancements/critereon/EntityHurtPlayerTrigger
 		ARG 4 amountTaken
 		ARG 5 wasBlocked
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/DamagePredicate;)V
+			ARG 1 player
+			ARG 2 damage
 		METHOD entityHurtPlayer (Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;)Lnet/minecraft/advancements/critereon/EntityHurtPlayerTrigger$TriggerInstance;
 			ARG 0 damageConditionBuilder
+		METHOD entityHurtPlayer (Lnet/minecraft/advancements/critereon/DamagePredicate;)Lnet/minecraft/advancements/critereon/EntityHurtPlayerTrigger$TriggerInstance;
+			ARG 0 damage
 		METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/damagesource/DamageSource;FFZ)Z
 			ARG 1 player
 			ARG 2 source

--- a/data/net/minecraft/advancements/critereon/EntityPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/EntityPredicate.mapping
@@ -37,7 +37,7 @@ CLASS net/minecraft/advancements/critereon/EntityPredicate
 		ARG 0 json
 	METHOD matches (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/entity/Entity;)Z
 		ARG 1 level
-		ARG 2 pos
+		ARG 2 position
 		ARG 3 entity
 	METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/Entity;)Z
 		ARG 1 player
@@ -92,11 +92,11 @@ CLASS net/minecraft/advancements/critereon/EntityPredicate
 			ARG 2 json
 		METHOD fromJson (Lcom/google/gson/JsonObject;Ljava/lang/String;Lnet/minecraft/advancements/critereon/DeserializationContext;)Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;
 			ARG 0 json
-			ARG 1 name
+			ARG 1 property
 			ARG 2 context
 		METHOD fromJsonArray (Lcom/google/gson/JsonObject;Ljava/lang/String;Lnet/minecraft/advancements/critereon/DeserializationContext;)[Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;
 			ARG 0 json
-			ARG 1 name
+			ARG 1 property
 			ARG 2 context
 		METHOD matches (Lnet/minecraft/world/level/storage/loot/LootContext;)Z
 			ARG 1 lootContext

--- a/data/net/minecraft/advancements/critereon/EntityPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/EntityPredicate.mapping
@@ -1,12 +1,43 @@
 CLASS net/minecraft/advancements/critereon/EntityPredicate
+	METHOD <init> (Lnet/minecraft/advancements/critereon/EntityTypePredicate;Lnet/minecraft/advancements/critereon/DistancePredicate;Lnet/minecraft/advancements/critereon/LocationPredicate;Lnet/minecraft/advancements/critereon/LocationPredicate;Lnet/minecraft/advancements/critereon/MobEffectsPredicate;Lnet/minecraft/advancements/critereon/NbtPredicate;Lnet/minecraft/advancements/critereon/EntityFlagsPredicate;Lnet/minecraft/advancements/critereon/EntityEquipmentPredicate;Lnet/minecraft/advancements/critereon/PlayerPredicate;Lnet/minecraft/advancements/critereon/FishingHookPredicate;Lnet/minecraft/advancements/critereon/LighthingBoltPredicate;Ljava/lang/String;Lnet/minecraft/resources/ResourceLocation;)V
+		ARG 1 entityType
+		ARG 2 distanceToPlayer
+		ARG 3 location
+		ARG 4 steppingOnLocation
+		ARG 5 effects
+		ARG 6 nbt
+		ARG 7 flags
+		ARG 8 equipment
+		ARG 9 player
+		ARG 10 fishingHook
+		ARG 11 lightningBolt
+		ARG 12 team
+		ARG 13 catType
+	METHOD <init> (Lnet/minecraft/advancements/critereon/EntityTypePredicate;Lnet/minecraft/advancements/critereon/DistancePredicate;Lnet/minecraft/advancements/critereon/LocationPredicate;Lnet/minecraft/advancements/critereon/LocationPredicate;Lnet/minecraft/advancements/critereon/MobEffectsPredicate;Lnet/minecraft/advancements/critereon/NbtPredicate;Lnet/minecraft/advancements/critereon/EntityFlagsPredicate;Lnet/minecraft/advancements/critereon/EntityEquipmentPredicate;Lnet/minecraft/advancements/critereon/PlayerPredicate;Lnet/minecraft/advancements/critereon/FishingHookPredicate;Lnet/minecraft/advancements/critereon/LighthingBoltPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate;Ljava/lang/String;Lnet/minecraft/resources/ResourceLocation;)V
+		ARG 1 entityType
+		ARG 2 distanceToPlayer
+		ARG 3 location
+		ARG 4 steppingOnLocation
+		ARG 5 effects
+		ARG 6 nbt
+		ARG 7 flags
+		ARG 8 equipment
+		ARG 9 player
+		ARG 10 fishingHook
+		ARG 11 lightningBolt
+		ARG 12 vehicle
+		ARG 13 passenger
+		ARG 14 targetedEntity
+		ARG 15 team
+		ARG 16 catType
 	METHOD createContext (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/level/storage/loot/LootContext;
 		ARG 0 player
 		ARG 1 entity
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/EntityPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD matches (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/entity/Entity;)Z
 		ARG 1 level
-		ARG 2 vector
+		ARG 2 pos
 		ARG 3 entity
 	METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/Entity;)Z
 		ARG 1 player
@@ -15,17 +46,19 @@ CLASS net/minecraft/advancements/critereon/EntityPredicate
 		METHOD catType (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
 			ARG 1 catType
 		METHOD distance (Lnet/minecraft/advancements/critereon/DistancePredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
-			ARG 1 distance
+			ARG 1 distanceToPlayer
 		METHOD effects (Lnet/minecraft/advancements/critereon/MobEffectsPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
 			ARG 1 effects
 		METHOD entityType (Lnet/minecraft/advancements/critereon/EntityTypePredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
-			ARG 1 type
+			ARG 1 entityType
 		METHOD equipment (Lnet/minecraft/advancements/critereon/EntityEquipmentPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
 			ARG 1 equipment
 		METHOD fishingHook (Lnet/minecraft/advancements/critereon/FishingHookPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
 			ARG 1 fishing
 		METHOD flags (Lnet/minecraft/advancements/critereon/EntityFlagsPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
 			ARG 1 flags
+		METHOD lighthingBolt (Lnet/minecraft/advancements/critereon/LighthingBoltPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
+			ARG 1 lightningBolt
 		METHOD located (Lnet/minecraft/advancements/critereon/LocationPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
 			ARG 1 location
 		METHOD nbt (Lnet/minecraft/advancements/critereon/NbtPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
@@ -33,38 +66,44 @@ CLASS net/minecraft/advancements/critereon/EntityPredicate
 		METHOD of (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
 			ARG 1 catType
 		METHOD of (Lnet/minecraft/tags/Tag;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
-			ARG 1 type
+			ARG 1 entityType
 		METHOD of (Lnet/minecraft/world/entity/EntityType;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
-			ARG 1 type
+			ARG 1 entityType
+		METHOD passenger (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
+			ARG 1 passenger
 		METHOD player (Lnet/minecraft/advancements/critereon/PlayerPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
 			ARG 1 player
+		METHOD steppingOn (Lnet/minecraft/advancements/critereon/LocationPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
+			ARG 1 steppingOnLocation
 		METHOD targetedEntity (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
-			ARG 1 target
+			ARG 1 targetedEntity
 		METHOD team (Ljava/lang/String;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
 			ARG 1 team
 		METHOD vehicle (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;
-			ARG 1 mount
+			ARG 1 vehicle
 	CLASS Composite
+		METHOD <init> ([Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition;)V
+			ARG 1 conditions
 		METHOD create ([Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition;)Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;
 			ARG 0 conditions
 		METHOD fromElement (Ljava/lang/String;Lnet/minecraft/advancements/critereon/DeserializationContext;Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;
 			ARG 0 name
-			ARG 1 conditions
-			ARG 2 element
-		METHOD fromJson (Lcom/google/gson/JsonObject;Ljava/lang/String;Lnet/minecraft/advancements/critereon/DeserializationContext;)Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;
-			ARG 0 jsonObject
-			ARG 1 name
-			ARG 2 conditions
-		METHOD fromJsonArray (Lcom/google/gson/JsonObject;Ljava/lang/String;Lnet/minecraft/advancements/critereon/DeserializationContext;)[Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;
-			ARG 0 jsonObject
-			ARG 1 name
-			ARG 2 conditions
-		METHOD matches (Lnet/minecraft/world/level/storage/loot/LootContext;)Z
 			ARG 1 context
+			ARG 2 json
+		METHOD fromJson (Lcom/google/gson/JsonObject;Ljava/lang/String;Lnet/minecraft/advancements/critereon/DeserializationContext;)Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;
+			ARG 0 json
+			ARG 1 name
+			ARG 2 context
+		METHOD fromJsonArray (Lcom/google/gson/JsonObject;Ljava/lang/String;Lnet/minecraft/advancements/critereon/DeserializationContext;)[Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;
+			ARG 0 json
+			ARG 1 name
+			ARG 2 context
+		METHOD matches (Lnet/minecraft/world/level/storage/loot/LootContext;)Z
+			ARG 1 lootContext
 		METHOD toJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonElement;
-			ARG 1 serializer
+			ARG 1 context
 		METHOD toJson ([Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonElement;
 			ARG 0 predicates
-			ARG 1 serializer
+			ARG 1 context
 		METHOD wrap (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;
 			ARG 0 entityCondition

--- a/data/net/minecraft/advancements/critereon/EntityTypePredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/EntityTypePredicate.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/advancements/critereon/EntityTypePredicate
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/EntityTypePredicate;
 		ARG 0 json
+	METHOD lambda$fromJson$0 (Lnet/minecraft/resources/ResourceLocation;)Lcom/google/gson/JsonSyntaxException;
+		ARG 0 entityTagId
 	METHOD matches (Lnet/minecraft/world/entity/EntityType;)Z
 		ARG 1 type
 	METHOD of (Lnet/minecraft/tags/Tag;)Lnet/minecraft/advancements/critereon/EntityTypePredicate;

--- a/data/net/minecraft/advancements/critereon/EntityTypePredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/EntityTypePredicate.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/advancements/critereon/EntityTypePredicate
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/EntityTypePredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD matches (Lnet/minecraft/world/entity/EntityType;)Z
 		ARG 1 type
 	METHOD of (Lnet/minecraft/tags/Tag;)Lnet/minecraft/advancements/critereon/EntityTypePredicate;
@@ -11,8 +11,12 @@ CLASS net/minecraft/advancements/critereon/EntityTypePredicate
 		METHOD matches (Lnet/minecraft/world/entity/EntityType;)Z
 			ARG 1 type
 	CLASS TagPredicate
+		METHOD <init> (Lnet/minecraft/tags/Tag;)V
+			ARG 1 tag
 		METHOD matches (Lnet/minecraft/world/entity/EntityType;)Z
 			ARG 1 type
 	CLASS TypePredicate
+		METHOD <init> (Lnet/minecraft/world/entity/EntityType;)V
+			ARG 1 type
 		METHOD matches (Lnet/minecraft/world/entity/EntityType;)Z
 			ARG 1 type

--- a/data/net/minecraft/advancements/critereon/FilledBucketTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/FilledBucketTrigger.mapping
@@ -15,6 +15,6 @@ CLASS net/minecraft/advancements/critereon/FilledBucketTrigger
 		METHOD filledBucket (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/FilledBucketTrigger$TriggerInstance;
 			ARG 0 item
 		METHOD matches (Lnet/minecraft/world/item/ItemStack;)Z
-			ARG 1 item
+			ARG 1 stack
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/FilledBucketTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/FilledBucketTrigger.mapping
@@ -3,13 +3,18 @@ CLASS net/minecraft/advancements/critereon/FilledBucketTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/advancements/critereon/FilledBucketTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;)V
 		ARG 1 player
 		ARG 2 stack
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+			ARG 1 player
+			ARG 2 item
 		METHOD filledBucket (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/FilledBucketTrigger$TriggerInstance;
-			ARG 0 itemCondition
+			ARG 0 item
 		METHOD matches (Lnet/minecraft/world/item/ItemStack;)Z
-			ARG 1 stack
+			ARG 1 item
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/FishingHookPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/FishingHookPredicate.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/advancements/critereon/FishingHookPredicate
 	METHOD <init> (Z)V
-		ARG 1 isOpenWater
+		ARG 1 inOpenWater
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/FishingHookPredicate;
 		ARG 0 json
 	METHOD inOpenWater (Z)Lnet/minecraft/advancements/critereon/FishingHookPredicate;
-		ARG 0 isOpenWater
+		ARG 0 inOpenWater
 	METHOD matches (Lnet/minecraft/world/entity/Entity;)Z
 		ARG 1 entity

--- a/data/net/minecraft/advancements/critereon/FishingHookPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/FishingHookPredicate.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/advancements/critereon/FishingHookPredicate
+	METHOD <init> (Z)V
+		ARG 1 isOpenWater
+	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/FishingHookPredicate;
+		ARG 0 json
+	METHOD inOpenWater (Z)Lnet/minecraft/advancements/critereon/FishingHookPredicate;
+		ARG 0 isOpenWater
+	METHOD matches (Lnet/minecraft/world/entity/Entity;)Z
+		ARG 1 entity

--- a/data/net/minecraft/advancements/critereon/FishingRodHookedTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/FishingRodHookedTrigger.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/advancements/critereon/FishingRodHookedTrigger
 		ARG 1 player
 		ARG 2 rod
 		ARG 3 entity
-		ARG 4 items
+		ARG 4 stacks
 	CLASS TriggerInstance
 		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
 			ARG 1 player
@@ -23,6 +23,6 @@ CLASS net/minecraft/advancements/critereon/FishingRodHookedTrigger
 		METHOD matches (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/storage/loot/LootContext;Ljava/util/Collection;)Z
 			ARG 1 rod
 			ARG 2 context
-			ARG 3 items
+			ARG 3 stacks
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/FishingRodHookedTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/FishingRodHookedTrigger.mapping
@@ -3,12 +3,19 @@ CLASS net/minecraft/advancements/critereon/FishingRodHookedTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/storage/loot/LootContext;Ljava/util/Collection;Lnet/minecraft/advancements/critereon/FishingRodHookedTrigger$TriggerInstance;)Z
+		ARG 3 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/projectile/FishingHook;Ljava/util/Collection;)V
 		ARG 1 player
 		ARG 2 rod
 		ARG 3 entity
 		ARG 4 items
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+			ARG 1 player
+			ARG 2 rod
+			ARG 3 entity
+			ARG 4 item
 		METHOD fishedItem (Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/FishingRodHookedTrigger$TriggerInstance;
 			ARG 0 rod
 			ARG 1 bobber

--- a/data/net/minecraft/advancements/critereon/FluidPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/FluidPredicate.mapping
@@ -1,6 +1,17 @@
 CLASS net/minecraft/advancements/critereon/FluidPredicate
+	METHOD <init> (Lnet/minecraft/tags/Tag;Lnet/minecraft/world/level/material/Fluid;Lnet/minecraft/advancements/critereon/StatePropertiesPredicate;)V
+		ARG 1 tag
+		ARG 2 fluid
+		ARG 3 properties
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/FluidPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD matches (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/core/BlockPos;)Z
 		ARG 1 level
 		ARG 2 pos
+	CLASS Builder
+		METHOD of (Lnet/minecraft/tags/Tag;)Lnet/minecraft/advancements/critereon/FluidPredicate$Builder;
+			ARG 1 fluids
+		METHOD of (Lnet/minecraft/world/level/material/Fluid;)Lnet/minecraft/advancements/critereon/FluidPredicate$Builder;
+			ARG 1 fluid
+		METHOD setProperties (Lnet/minecraft/advancements/critereon/StatePropertiesPredicate;)Lnet/minecraft/advancements/critereon/FluidPredicate$Builder;
+			ARG 1 properties

--- a/data/net/minecraft/advancements/critereon/InventoryChangeTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/InventoryChangeTrigger.mapping
@@ -3,6 +3,8 @@ CLASS net/minecraft/advancements/critereon/InventoryChangeTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/entity/player/Inventory;Lnet/minecraft/world/item/ItemStack;IIILnet/minecraft/advancements/critereon/InventoryChangeTrigger$TriggerInstance;)Z
+		ARG 5 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/player/Inventory;Lnet/minecraft/world/item/ItemStack;)V
 		ARG 1 player
 		ARG 2 inventory

--- a/data/net/minecraft/advancements/critereon/InventoryChangeTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/InventoryChangeTrigger.mapping
@@ -15,8 +15,14 @@ CLASS net/minecraft/advancements/critereon/InventoryChangeTrigger
 		ARG 5 empty
 		ARG 6 occupied
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;[Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+			ARG 1 player
+			ARG 2 slotsOccupied
+			ARG 3 slotsFull
+			ARG 4 slotsEmpty
+			ARG 5 predicates
 		METHOD hasItems ([Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/InventoryChangeTrigger$TriggerInstance;
-			ARG 0 itemConditions
+			ARG 0 items
 		METHOD hasItems ([Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/advancements/critereon/InventoryChangeTrigger$TriggerInstance;
 			ARG 0 items
 		METHOD matches (Lnet/minecraft/world/entity/player/Inventory;Lnet/minecraft/world/item/ItemStack;III)Z

--- a/data/net/minecraft/advancements/critereon/ItemDurabilityTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/ItemDurabilityTrigger.mapping
@@ -3,15 +3,25 @@ CLASS net/minecraft/advancements/critereon/ItemDurabilityTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/item/ItemStack;ILnet/minecraft/advancements/critereon/ItemDurabilityTrigger$TriggerInstance;)Z
+		ARG 2 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;I)V
 		ARG 1 player
 		ARG 2 item
 		ARG 3 newDurability
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)V
+			ARG 1 player
+			ARG 2 item
+			ARG 3 durability
+			ARG 4 delta
 		METHOD changedDurability (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)Lnet/minecraft/advancements/critereon/ItemDurabilityTrigger$TriggerInstance;
 			ARG 0 player
 			ARG 1 item
 			ARG 2 durability
+		METHOD changedDurability (Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)Lnet/minecraft/advancements/critereon/ItemDurabilityTrigger$TriggerInstance;
+			ARG 0 item
+			ARG 1 durability
 		METHOD matches (Lnet/minecraft/world/item/ItemStack;I)Z
 			ARG 1 item
 			ARG 2 durability

--- a/data/net/minecraft/advancements/critereon/ItemPickedUpByEntityTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/ItemPickedUpByEntityTrigger.mapping
@@ -3,14 +3,20 @@ CLASS net/minecraft/advancements/critereon/ItemPickedUpByEntityTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/advancements/critereon/ItemPickedUpByEntityTrigger$TriggerInstance;)Z
+		ARG 3 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/Entity;)V
 		ARG 1 player
 		ARG 2 stack
 		ARG 3 entity
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+			ARG 2 item
+			ARG 3 entity
 		METHOD itemPickedUpByEntity (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)Lnet/minecraft/advancements/critereon/ItemPickedUpByEntityTrigger$TriggerInstance;
 			ARG 0 player
-			ARG 1 stack
+			ARG 1 item
 			ARG 2 entity
 		METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/storage/loot/LootContext;)Z
 			ARG 1 player

--- a/data/net/minecraft/advancements/critereon/ItemPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/ItemPredicate.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/advancements/critereon/ItemPredicate
 		METHOD hasNbt (Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
 			ARG 1 nbt
 		METHOD hasStoredEnchantment (Lnet/minecraft/advancements/critereon/EnchantmentPredicate;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
-			ARG 1 storedEnchantments
+			ARG 1 storedEnchantment
 		METHOD isPotion (Lnet/minecraft/world/item/alchemy/Potion;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
 			ARG 1 potion
 		METHOD of (Lnet/minecraft/tags/Tag;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;

--- a/data/net/minecraft/advancements/critereon/ItemPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/ItemPredicate.mapping
@@ -1,14 +1,33 @@
 CLASS net/minecraft/advancements/critereon/ItemPredicate
+	METHOD <init> (Lnet/minecraft/tags/Tag;Ljava/util/Set;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;[Lnet/minecraft/advancements/critereon/EnchantmentPredicate;[Lnet/minecraft/advancements/critereon/EnchantmentPredicate;Lnet/minecraft/world/item/alchemy/Potion;Lnet/minecraft/advancements/critereon/NbtPredicate;)V
+		ARG 1 tag
+		ARG 2 items
+		ARG 3 count
+		ARG 4 durability
+		ARG 5 enchantments
+		ARG 6 storedEnchantments
+		ARG 7 potion
+		ARG 8 nbt
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/ItemPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD fromJsonArray (Lcom/google/gson/JsonElement;)[Lnet/minecraft/advancements/critereon/ItemPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD matches (Lnet/minecraft/world/item/ItemStack;)Z
 		ARG 1 item
 	CLASS Builder
+		METHOD hasDurability (Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
+			ARG 1 durability
 		METHOD hasEnchantment (Lnet/minecraft/advancements/critereon/EnchantmentPredicate;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
-			ARG 1 enchantmentCondition
+			ARG 1 enchantment
 		METHOD hasNbt (Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
 			ARG 1 nbt
+		METHOD hasStoredEnchantment (Lnet/minecraft/advancements/critereon/EnchantmentPredicate;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
+			ARG 1 storedEnchantments
+		METHOD isPotion (Lnet/minecraft/world/item/alchemy/Potion;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
+			ARG 1 potion
 		METHOD of (Lnet/minecraft/tags/Tag;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
 			ARG 1 tag
+		METHOD of ([Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
+			ARG 1 items
+		METHOD withCount (Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;
+			ARG 1 count

--- a/data/net/minecraft/advancements/critereon/ItemUsedOnBlockTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/ItemUsedOnBlockTrigger.mapping
@@ -3,11 +3,17 @@ CLASS net/minecraft/advancements/critereon/ItemUsedOnBlockTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/advancements/critereon/ItemUsedOnBlockTrigger$TriggerInstance;)Z
+		ARG 4 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;)V
 		ARG 1 player
 		ARG 2 pos
 		ARG 3 stack
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/LocationPredicate;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+			ARG 1 player
+			ARG 2 location
+			ARG 3 item
 		METHOD itemUsedOnBlock (Lnet/minecraft/advancements/critereon/LocationPredicate$Builder;Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;)Lnet/minecraft/advancements/critereon/ItemUsedOnBlockTrigger$TriggerInstance;
 			ARG 0 locationBuilder
 			ARG 1 stackBuilder

--- a/data/net/minecraft/advancements/critereon/KilledByCrossbowTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/KilledByCrossbowTrigger.mapping
@@ -3,10 +3,16 @@ CLASS net/minecraft/advancements/critereon/KilledByCrossbowTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Ljava/util/List;Ljava/util/Set;Lnet/minecraft/advancements/critereon/KilledByCrossbowTrigger$TriggerInstance;)Z
+		ARG 2 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Ljava/util/Collection;)V
 		ARG 1 player
 		ARG 2 entities
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;[Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)V
+			ARG 1 player
+			ARG 2 victims
+			ARG 3 uniqueEntityTypes
 		METHOD crossbowKilled (Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)Lnet/minecraft/advancements/critereon/KilledByCrossbowTrigger$TriggerInstance;
 			ARG 0 bounds
 		METHOD crossbowKilled ([Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;)Lnet/minecraft/advancements/critereon/KilledByCrossbowTrigger$TriggerInstance;

--- a/data/net/minecraft/advancements/critereon/KilledTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/KilledTrigger.mapping
@@ -5,6 +5,8 @@ CLASS net/minecraft/advancements/critereon/KilledTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/world/damagesource/DamageSource;Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;)Z
+		ARG 3 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/damagesource/DamageSource;)V
 		ARG 1 player
 		ARG 2 entity
@@ -38,8 +40,8 @@ CLASS net/minecraft/advancements/critereon/KilledTrigger
 		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
 			ARG 0 entityPredicateBuilder
 		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
-			ARG 0 entityBuilder
-			ARG 1 sourceBuilder
+			ARG 0 entityPredicateBuilder
+			ARG 1 killingBlowBuilder
 		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;Lnet/minecraft/advancements/critereon/DamageSourcePredicate;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
 			ARG 0 entityPredicateBuilder
 			ARG 1 killingBlow
@@ -47,7 +49,7 @@ CLASS net/minecraft/advancements/critereon/KilledTrigger
 			ARG 0 entityPredicate
 		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
 			ARG 0 entityPredicate
-			ARG 1 damageSourceBuilder
+			ARG 1 killingBlowBuilder
 		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/DamageSourcePredicate;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
 			ARG 0 entityPredicate
 			ARG 1 killingBlow

--- a/data/net/minecraft/advancements/critereon/KilledTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/KilledTrigger.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/advancements/critereon/KilledTrigger
+	METHOD <init> (Lnet/minecraft/resources/ResourceLocation;)V
+		ARG 1 id
 	METHOD createInstance (Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/DeserializationContext;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
 		ARG 1 json
 		ARG 2 entityPredicate
@@ -8,14 +10,46 @@ CLASS net/minecraft/advancements/critereon/KilledTrigger
 		ARG 2 entity
 		ARG 3 source
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/DamageSourcePredicate;)V
+			ARG 1 criterion
+			ARG 2 player
+			ARG 3 entityPredicate
+			ARG 4 killingBlow
+		METHOD entityKilledPlayer (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
+			ARG 0 entityPredicateBuilder
+		METHOD entityKilledPlayer (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
+			ARG 0 entityPredicateBuilder
+			ARG 1 killingBlowBuilder
+		METHOD entityKilledPlayer (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;Lnet/minecraft/advancements/critereon/DamageSourcePredicate;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
+			ARG 0 entityPredicateBuilder
+			ARG 1 killingBlow
+		METHOD entityKilledPlayer (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
+			ARG 0 entityPredicate
+		METHOD entityKilledPlayer (Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
+			ARG 0 entityPredicate
+			ARG 1 killingBlowBuilder
+		METHOD entityKilledPlayer (Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/DamageSourcePredicate;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
+			ARG 0 entityPredicate
+			ARG 1 killingBlow
 		METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/world/damagesource/DamageSource;)Z
 			ARG 1 player
 			ARG 2 context
 			ARG 3 source
 		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
-			ARG 0 builder
+			ARG 0 entityPredicateBuilder
 		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
 			ARG 0 entityBuilder
 			ARG 1 sourceBuilder
+		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;Lnet/minecraft/advancements/critereon/DamageSourcePredicate;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
+			ARG 0 entityPredicateBuilder
+			ARG 1 killingBlow
+		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
+			ARG 0 entityPredicate
+		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/DamageSourcePredicate$Builder;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
+			ARG 0 entityPredicate
+			ARG 1 damageSourceBuilder
+		METHOD playerKilledEntity (Lnet/minecraft/advancements/critereon/EntityPredicate;Lnet/minecraft/advancements/critereon/DamageSourcePredicate;)Lnet/minecraft/advancements/critereon/KilledTrigger$TriggerInstance;
+			ARG 0 entityPredicate
+			ARG 1 killingBlow
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/LevitationTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/LevitationTrigger.mapping
@@ -3,11 +3,17 @@ CLASS net/minecraft/advancements/critereon/LevitationTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/phys/Vec3;ILnet/minecraft/advancements/critereon/LevitationTrigger$TriggerInstance;)Z
+		ARG 3 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/phys/Vec3;I)V
 		ARG 1 player
 		ARG 2 startPos
 		ARG 3 duration
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/DistancePredicate;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)V
+			ARG 1 player
+			ARG 2 distance
+			ARG 3 duration
 		METHOD levitated (Lnet/minecraft/advancements/critereon/DistancePredicate;)Lnet/minecraft/advancements/critereon/LevitationTrigger$TriggerInstance;
 			ARG 0 distance
 		METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/phys/Vec3;I)Z

--- a/data/net/minecraft/advancements/critereon/LightPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/LightPredicate.mapping
@@ -1,6 +1,11 @@
 CLASS net/minecraft/advancements/critereon/LightPredicate
+	METHOD <init> (Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)V
+		ARG 1 composite
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/LightPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD matches (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/core/BlockPos;)Z
 		ARG 1 level
 		ARG 2 pos
+	CLASS Builder
+		METHOD setComposite (Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)Lnet/minecraft/advancements/critereon/LightPredicate$Builder;
+			ARG 1 composite

--- a/data/net/minecraft/advancements/critereon/LighthingBoltPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/LighthingBoltPredicate.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/advancements/critereon/LighthingBoltPredicate
+	METHOD <init> (Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;Lnet/minecraft/advancements/critereon/EntityPredicate;)V
+		ARG 1 blocksSetOnFire
+		ARG 2 entityStruck
+	METHOD blockSetOnFire (Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;)Lnet/minecraft/advancements/critereon/LighthingBoltPredicate;
+		ARG 0 blocksSetOnFire
+	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/LighthingBoltPredicate;
+		ARG 0 json

--- a/data/net/minecraft/advancements/critereon/LocationPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/LocationPredicate.mapping
@@ -1,6 +1,17 @@
 CLASS net/minecraft/advancements/critereon/LocationPredicate
+	METHOD <init> (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/level/levelgen/feature/StructureFeature;Lnet/minecraft/resources/ResourceKey;Ljava/lang/Boolean;Lnet/minecraft/advancements/critereon/LightPredicate;Lnet/minecraft/advancements/critereon/BlockPredicate;Lnet/minecraft/advancements/critereon/FluidPredicate;)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 biome
+		ARG 5 feature
+		ARG 6 dimension
+		ARG 7 smokey
+		ARG 8 light
+		ARG 9 block
+		ARG 10 fluid
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/LocationPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD inBiome (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/advancements/critereon/LocationPredicate;
 		ARG 0 biome
 	METHOD inDimension (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/advancements/critereon/LocationPredicate;
@@ -17,5 +28,19 @@ CLASS net/minecraft/advancements/critereon/LocationPredicate
 			ARG 1 biome
 		METHOD setBlock (Lnet/minecraft/advancements/critereon/BlockPredicate;)Lnet/minecraft/advancements/critereon/LocationPredicate$Builder;
 			ARG 1 block
+		METHOD setDimension (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/advancements/critereon/LocationPredicate$Builder;
+			ARG 1 dimension
+		METHOD setFeature (Lnet/minecraft/world/level/levelgen/feature/StructureFeature;)Lnet/minecraft/advancements/critereon/LocationPredicate$Builder;
+			ARG 1 feature
+		METHOD setFluid (Lnet/minecraft/advancements/critereon/FluidPredicate;)Lnet/minecraft/advancements/critereon/LocationPredicate$Builder;
+			ARG 1 fluid
+		METHOD setLight (Lnet/minecraft/advancements/critereon/LightPredicate;)Lnet/minecraft/advancements/critereon/LocationPredicate$Builder;
+			ARG 1 light
 		METHOD setSmokey (Ljava/lang/Boolean;)Lnet/minecraft/advancements/critereon/LocationPredicate$Builder;
 			ARG 1 smokey
+		METHOD setX (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)Lnet/minecraft/advancements/critereon/LocationPredicate$Builder;
+			ARG 1 x
+		METHOD setY (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)Lnet/minecraft/advancements/critereon/LocationPredicate$Builder;
+			ARG 1 y
+		METHOD setZ (Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)Lnet/minecraft/advancements/critereon/LocationPredicate$Builder;
+			ARG 1 z

--- a/data/net/minecraft/advancements/critereon/LocationTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/LocationTrigger.mapping
@@ -1,11 +1,21 @@
 CLASS net/minecraft/advancements/critereon/LocationTrigger
+	METHOD <init> (Lnet/minecraft/resources/ResourceLocation;)V
+		ARG 1 id
 	METHOD createInstance (Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/DeserializationContext;)Lnet/minecraft/advancements/critereon/LocationTrigger$TriggerInstance;
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/advancements/critereon/LocationTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;)V
 		ARG 1 player
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/LocationPredicate;)V
+			ARG 1 criterion
+			ARG 2 player
+			ARG 3 location
+		METHOD located (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/LocationTrigger$TriggerInstance;
+			ARG 0 entityPredicate
 		METHOD located (Lnet/minecraft/advancements/critereon/LocationPredicate;)Lnet/minecraft/advancements/critereon/LocationTrigger$TriggerInstance;
 			ARG 0 location
 		METHOD matches (Lnet/minecraft/server/level/ServerLevel;DDD)Z
@@ -15,3 +25,6 @@ CLASS net/minecraft/advancements/critereon/LocationTrigger
 			ARG 6 z
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions
+		METHOD walkOnBlockWithEquipment (Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/item/Item;)Lnet/minecraft/advancements/critereon/LocationTrigger$TriggerInstance;
+			ARG 0 block
+			ARG 1 item

--- a/data/net/minecraft/advancements/critereon/LootTableTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/LootTableTrigger.mapping
@@ -3,13 +3,18 @@ CLASS net/minecraft/advancements/critereon/LootTableTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/advancements/critereon/LootTableTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/resources/ResourceLocation;)V
 		ARG 1 player
-		ARG 2 generatedLoot
+		ARG 2 lootTable
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/resources/ResourceLocation;)V
+			ARG 1 player
+			ARG 2 lootTable
 		METHOD lootTableUsed (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/critereon/LootTableTrigger$TriggerInstance;
-			ARG 0 generatedLoot
+			ARG 0 lootTable
 		METHOD matches (Lnet/minecraft/resources/ResourceLocation;)Z
-			ARG 1 generatedLoot
+			ARG 1 lootTable
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/MinMaxBounds.mapping
+++ b/data/net/minecraft/advancements/critereon/MinMaxBounds.mapping
@@ -1,27 +1,38 @@
 CLASS net/minecraft/advancements/critereon/MinMaxBounds
+	METHOD <init> (Ljava/lang/Number;Ljava/lang/Number;)V
+		ARG 1 min
+		ARG 2 max
 	METHOD fromJson (Lcom/google/gson/JsonElement;Lnet/minecraft/advancements/critereon/MinMaxBounds;Ljava/util/function/BiFunction;Lnet/minecraft/advancements/critereon/MinMaxBounds$BoundsFactory;)Lnet/minecraft/advancements/critereon/MinMaxBounds;
-		ARG 0 element
+		ARG 0 json
 		ARG 1 defaultValue
-		ARG 2 biFunction
+		ARG 2 valueFactory
 		ARG 3 boundedFactory
 	METHOD fromReader (Lcom/mojang/brigadier/StringReader;Lnet/minecraft/advancements/critereon/MinMaxBounds$BoundsFromReaderFactory;Ljava/util/function/Function;Ljava/util/function/Supplier;Ljava/util/function/Function;)Lnet/minecraft/advancements/critereon/MinMaxBounds;
 		ARG 0 reader
-		ARG 1 minMaxReader
-		ARG 2 valueFunction
+		ARG 1 boundedFactory
+		ARG 2 valueFactory
 		ARG 3 commandExceptionSupplier
-		ARG 4 function
+		ARG 4 formatter
 	METHOD isAllowedInputChat (Lcom/mojang/brigadier/StringReader;)Z
 		ARG 0 reader
 	METHOD optionallyFormat (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
 		ARG 0 value
-		ARG 1 formatterFunction
+		ARG 1 formatter
 	METHOD readNumber (Lcom/mojang/brigadier/StringReader;Ljava/util/function/Function;Ljava/util/function/Supplier;)Ljava/lang/Number;
 		ARG 0 reader
 		ARG 1 stringToValueFunction
 		ARG 2 commandExceptionSupplier
 	CLASS Ints
+		METHOD <init> (Ljava/lang/Integer;Ljava/lang/Integer;)V
+			ARG 1 min
+			ARG 2 max
 		METHOD atLeast (I)Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;
-			ARG 0 value
+			ARG 0 min
+		METHOD atMost (I)Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;
+			ARG 0 max
+		METHOD between (II)Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;
+			ARG 0 min
+			ARG 1 max
 		METHOD create (Lcom/mojang/brigadier/StringReader;Ljava/lang/Integer;Ljava/lang/Integer;)Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;
 			ARG 0 reader
 			ARG 1 min
@@ -29,13 +40,58 @@ CLASS net/minecraft/advancements/critereon/MinMaxBounds
 		METHOD exactly (I)Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;
 			ARG 0 value
 		METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;
-			ARG 0 element
+			ARG 0 json
 		METHOD fromReader (Lcom/mojang/brigadier/StringReader;)Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;
 			ARG 0 reader
 		METHOD fromReader (Lcom/mojang/brigadier/StringReader;Ljava/util/function/Function;)Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;
 			ARG 0 reader
 			ARG 1 valueFunction
+		METHOD lambda$fromReader$0 (Ljava/lang/Integer;)Ljava/lang/Integer;
+			ARG 0 value
 		METHOD matches (I)Z
+			ARG 1 value
+		METHOD matchesSqr (J)Z
 			ARG 1 value
 		METHOD squareOpt (Ljava/lang/Integer;)Ljava/lang/Long;
 			ARG 0 value
+	CLASS Doubles
+		METHOD <init> (Ljava/lang/Double;Ljava/lang/Double;)V
+			ARG 1 min
+			ARG 2 max
+		METHOD atLeast (D)Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;
+			ARG 0 min
+		METHOD atMost (D)Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;
+			ARG 0 max
+		METHOD between (DD)Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;
+			ARG 0 min
+			ARG 2 max
+		METHOD create (Lcom/mojang/brigadier/StringReader;Ljava/lang/Double;Ljava/lang/Double;)Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;
+			ARG 0 reader
+			ARG 1 min
+			ARG 2 max
+		METHOD exactly (D)Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;
+			ARG 0 value
+		METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;
+			ARG 0 json
+		METHOD fromReader (Lcom/mojang/brigadier/StringReader;)Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;
+			ARG 0 reader
+		METHOD fromReader (Lcom/mojang/brigadier/StringReader;Ljava/util/function/Function;)Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;
+			ARG 0 reader
+			ARG 1 formatter
+		METHOD lambda$fromReader$0 (Ljava/lang/Double;)Ljava/lang/Double;
+			ARG 0 value
+		METHOD matches (D)Z
+			ARG 1 value
+		METHOD matchesSqr (D)Z
+			ARG 1 value
+		METHOD squareOpt (Ljava/lang/Double;)Ljava/lang/Double;
+			ARG 0 value
+	CLASS BoundsFactory
+		METHOD create (Ljava/lang/Number;Ljava/lang/Number;)Lnet/minecraft/advancements/critereon/MinMaxBounds;
+			ARG 1 min
+			ARG 2 max
+	CLASS BoundsFromReaderFactory
+		METHOD create (Lcom/mojang/brigadier/StringReader;Ljava/lang/Number;Ljava/lang/Number;)Lnet/minecraft/advancements/critereon/MinMaxBounds;
+			ARG 1 reader
+			ARG 2 min
+			ARG 3 max

--- a/data/net/minecraft/advancements/critereon/MobEffectsPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/MobEffectsPredicate.mapping
@@ -1,16 +1,26 @@
 CLASS net/minecraft/advancements/critereon/MobEffectsPredicate
+	METHOD <init> (Ljava/util/Map;)V
+		ARG 1 effects
 	METHOD and (Lnet/minecraft/world/effect/MobEffect;)Lnet/minecraft/advancements/critereon/MobEffectsPredicate;
 		ARG 1 effect
+	METHOD and (Lnet/minecraft/world/effect/MobEffect;Lnet/minecraft/advancements/critereon/MobEffectsPredicate$MobEffectInstancePredicate;)Lnet/minecraft/advancements/critereon/MobEffectsPredicate;
+		ARG 1 effect
+		ARG 2 predicate
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/MobEffectsPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD matches (Ljava/util/Map;)Z
-		ARG 1 potions
+		ARG 1 effects
 	METHOD matches (Lnet/minecraft/world/entity/Entity;)Z
 		ARG 1 entity
 	METHOD matches (Lnet/minecraft/world/entity/LivingEntity;)Z
 		ARG 1 entity
 	CLASS MobEffectInstancePredicate
+		METHOD <init> (Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+			ARG 1 amplifier
+			ARG 2 duration
+			ARG 3 ambient
+			ARG 4 visible
 		METHOD fromJson (Lcom/google/gson/JsonObject;)Lnet/minecraft/advancements/critereon/MobEffectsPredicate$MobEffectInstancePredicate;
-			ARG 0 object
+			ARG 0 json
 		METHOD matches (Lnet/minecraft/world/effect/MobEffectInstance;)Z
 			ARG 1 effect

--- a/data/net/minecraft/advancements/critereon/NbtPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/NbtPredicate.mapping
@@ -1,11 +1,13 @@
 CLASS net/minecraft/advancements/critereon/NbtPredicate
+	METHOD <init> (Lnet/minecraft/nbt/CompoundTag;)V
+		ARG 1 tag
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/NbtPredicate;
 		ARG 0 json
 	METHOD getEntityTagToCompare (Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/nbt/CompoundTag;
 		ARG 0 entity
 	METHOD matches (Lnet/minecraft/nbt/Tag;)Z
-		ARG 1 nbt
+		ARG 1 tag
 	METHOD matches (Lnet/minecraft/world/entity/Entity;)Z
 		ARG 1 entity
 	METHOD matches (Lnet/minecraft/world/item/ItemStack;)Z
-		ARG 1 item
+		ARG 1 stack

--- a/data/net/minecraft/advancements/critereon/NetherTravelTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/NetherTravelTrigger.mapping
@@ -3,10 +3,17 @@ CLASS net/minecraft/advancements/critereon/NetherTravelTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/advancements/critereon/NetherTravelTrigger$TriggerInstance;)Z
+		ARG 2 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/phys/Vec3;)V
 		ARG 1 player
 		ARG 2 enteredNetherPosition
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/LocationPredicate;Lnet/minecraft/advancements/critereon/LocationPredicate;Lnet/minecraft/advancements/critereon/DistancePredicate;)V
+			ARG 1 player
+			ARG 2 entered
+			ARG 3 exited
+			ARG 4 distance
 		METHOD matches (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;DDD)Z
 			ARG 1 level
 			ARG 2 enteredNetherPosition

--- a/data/net/minecraft/advancements/critereon/PlacedBlockTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/PlacedBlockTrigger.mapping
@@ -5,11 +5,21 @@ CLASS net/minecraft/advancements/critereon/PlacedBlockTrigger
 		ARG 3 conditionsParser
 	METHOD deserializeBlock (Lcom/google/gson/JsonObject;)Lnet/minecraft/world/level/block/Block;
 		ARG 0 object
+	METHOD lambda$createInstance$0 (Lnet/minecraft/world/level/block/Block;Ljava/lang/String;)V
+		ARG 1 property
+	METHOD lambda$trigger$2 (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/advancements/critereon/PlacedBlockTrigger$TriggerInstance;)Z
+		ARG 4 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;)V
 		ARG 1 player
 		ARG 2 pos
 		ARG 3 item
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/world/level/block/Block;Lnet/minecraft/advancements/critereon/StatePropertiesPredicate;Lnet/minecraft/advancements/critereon/LocationPredicate;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+			ARG 1 player
+			ARG 2 block
+			ARG 3 state
+			ARG 4 location
+			ARG 5 item
 		METHOD matches (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item/ItemStack;)Z
 			ARG 1 state
 			ARG 2 pos

--- a/data/net/minecraft/advancements/critereon/PlayerHurtEntityTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/PlayerHurtEntityTrigger.mapping
@@ -3,6 +3,8 @@ CLASS net/minecraft/advancements/critereon/PlayerHurtEntityTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/world/damagesource/DamageSource;FFZLnet/minecraft/advancements/critereon/PlayerHurtEntityTrigger$TriggerInstance;)Z
+		ARG 6 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/damagesource/DamageSource;FFZ)V
 		ARG 1 player
 		ARG 2 entity
@@ -11,6 +13,10 @@ CLASS net/minecraft/advancements/critereon/PlayerHurtEntityTrigger
 		ARG 5 amountTaken
 		ARG 6 blocked
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/DamagePredicate;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+			ARG 2 damage
+			ARG 3 entity
 		METHOD matches (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/world/damagesource/DamageSource;FFZ)Z
 			ARG 1 player
 			ARG 2 context
@@ -19,6 +25,16 @@ CLASS net/minecraft/advancements/critereon/PlayerHurtEntityTrigger
 			ARG 5 taken
 			ARG 6 blocked
 		METHOD playerHurtEntity (Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;)Lnet/minecraft/advancements/critereon/PlayerHurtEntityTrigger$TriggerInstance;
-			ARG 0 builder
+			ARG 0 damageBuilder
+		METHOD playerHurtEntity (Lnet/minecraft/advancements/critereon/DamagePredicate$Builder;Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/PlayerHurtEntityTrigger$TriggerInstance;
+			ARG 0 damageBuilder
+			ARG 1 entity
+		METHOD playerHurtEntity (Lnet/minecraft/advancements/critereon/DamagePredicate;)Lnet/minecraft/advancements/critereon/PlayerHurtEntityTrigger$TriggerInstance;
+			ARG 0 damage
+		METHOD playerHurtEntity (Lnet/minecraft/advancements/critereon/DamagePredicate;Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/PlayerHurtEntityTrigger$TriggerInstance;
+			ARG 0 damage
+			ARG 1 entity
+		METHOD playerHurtEntity (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/PlayerHurtEntityTrigger$TriggerInstance;
+			ARG 0 entity
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/PlayerInteractTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/PlayerInteractTrigger.mapping
@@ -3,17 +3,23 @@ CLASS net/minecraft/advancements/critereon/PlayerInteractTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/advancements/critereon/PlayerInteractTrigger$TriggerInstance;)Z
+		ARG 2 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/Entity;)V
 		ARG 1 player
-		ARG 2 stack
+		ARG 2 item
 		ARG 3 entity
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+			ARG 2 item
+			ARG 3 entity
 		METHOD itemUsedOnEntity (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)Lnet/minecraft/advancements/critereon/PlayerInteractTrigger$TriggerInstance;
 			ARG 0 player
-			ARG 1 stack
+			ARG 1 item
 			ARG 2 entity
 		METHOD matches (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/storage/loot/LootContext;)Z
-			ARG 1 stack
-			ARG 2 context
+			ARG 1 item
+			ARG 2 lootContext
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions

--- a/data/net/minecraft/advancements/critereon/PlayerPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/PlayerPredicate.mapping
@@ -1,11 +1,18 @@
 CLASS net/minecraft/advancements/critereon/PlayerPredicate
+	METHOD <init> (Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;Lnet/minecraft/world/level/GameType;Ljava/util/Map;Lit/unimi/dsi/fastutil/objects/Object2BooleanMap;Ljava/util/Map;Lnet/minecraft/advancements/critereon/EntityPredicate;)V
+		ARG 1 level
+		ARG 2 gameType
+		ARG 3 stats
+		ARG 4 recipes
+		ARG 5 advancements
+		ARG 6 lookingAt
 	METHOD advancementPredicateFromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/PlayerPredicate$AdvancementPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/PlayerPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD getStat (Lnet/minecraft/stats/StatType;Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/stats/Stat;
 		ARG 0 type
-		ARG 1 identifier
+		ARG 1 id
 	METHOD getStatValueId (Lnet/minecraft/stats/Stat;)Lnet/minecraft/resources/ResourceLocation;
 		ARG 0 stat
 	METHOD matches (Lnet/minecraft/world/entity/Entity;)Z

--- a/data/net/minecraft/advancements/critereon/RecipeUnlockedTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/RecipeUnlockedTrigger.mapping
@@ -3,12 +3,17 @@ CLASS net/minecraft/advancements/critereon/RecipeUnlockedTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/item/crafting/Recipe;Lnet/minecraft/advancements/critereon/RecipeUnlockedTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/crafting/Recipe;)V
 		ARG 1 player
 		ARG 2 recipe
 	METHOD unlocked (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/advancements/critereon/RecipeUnlockedTrigger$TriggerInstance;
-		ARG 0 recipeID
+		ARG 0 recipe
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/resources/ResourceLocation;)V
+			ARG 1 player
+			ARG 2 recipe
 		METHOD matches (Lnet/minecraft/world/item/crafting/Recipe;)Z
 			ARG 1 recipe
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;

--- a/data/net/minecraft/advancements/critereon/ShotCrossbowTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/ShotCrossbowTrigger.mapping
@@ -3,13 +3,20 @@ CLASS net/minecraft/advancements/critereon/ShotCrossbowTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/advancements/critereon/ShotCrossbowTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;)V
 		ARG 1 shooter
 		ARG 2 stack
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+			ARG 1 player
+			ARG 2 item
 		METHOD matches (Lnet/minecraft/world/item/ItemStack;)Z
-			ARG 1 stack
+			ARG 1 item
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions
+		METHOD shotCrossbow (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/ShotCrossbowTrigger$TriggerInstance;
+			ARG 0 item
 		METHOD shotCrossbow (Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/advancements/critereon/ShotCrossbowTrigger$TriggerInstance;
-			ARG 0 itemProvider
+			ARG 0 item

--- a/data/net/minecraft/advancements/critereon/SimpleCriterionTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/SimpleCriterionTrigger.mapping
@@ -7,13 +7,13 @@ CLASS net/minecraft/advancements/critereon/SimpleCriterionTrigger
 		ARG 2 conditions
 	METHOD createInstance (Lcom/google/gson/JsonObject;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/DeserializationContext;)Lnet/minecraft/advancements/critereon/AbstractCriterionTriggerInstance;
 		ARG 1 json
-		ARG 2 entityPredicate
-		ARG 3 conditionsParser
+		ARG 2 player
+		ARG 3 context
 	METHOD removePlayerListener (Lnet/minecraft/server/PlayerAdvancements;Lnet/minecraft/advancements/CriterionTrigger$Listener;)V
 		ARG 1 playerAdvancements
 		ARG 2 listener
 	METHOD removePlayerListeners (Lnet/minecraft/server/PlayerAdvancements;)V
 		ARG 1 playerAdvancements
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Ljava/util/function/Predicate;)V
-		ARG 1 serverPlayer
+		ARG 1 player
 		ARG 2 testTrigger

--- a/data/net/minecraft/advancements/critereon/SlideDownBlockTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/SlideDownBlockTrigger.mapping
@@ -4,11 +4,19 @@ CLASS net/minecraft/advancements/critereon/SlideDownBlockTrigger
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
 	METHOD deserializeBlock (Lcom/google/gson/JsonObject;)Lnet/minecraft/world/level/block/Block;
-		ARG 0 object
+		ARG 0 json
+	METHOD lambda$createInstance$0 (Lnet/minecraft/world/level/block/Block;Ljava/lang/String;)V
+		ARG 1 property
+	METHOD lambda$trigger$2 (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/advancements/critereon/SlideDownBlockTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/level/block/state/BlockState;)V
 		ARG 1 player
 		ARG 2 state
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/world/level/block/Block;Lnet/minecraft/advancements/critereon/StatePropertiesPredicate;)V
+			ARG 1 player
+			ARG 2 block
+			ARG 3 state
 		METHOD matches (Lnet/minecraft/world/level/block/state/BlockState;)Z
 			ARG 1 state
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;

--- a/data/net/minecraft/advancements/critereon/StartRidingTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/StartRidingTrigger.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/advancements/critereon/StartRidingTrigger
+	METHOD lambda$trigger$0 (Lnet/minecraft/advancements/critereon/StartRidingTrigger$TriggerInstance;)Z
+		ARG 0 instance
+	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;)V
+		ARG 1 player
+	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+		METHOD playerStartsRiding (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;)Lnet/minecraft/advancements/critereon/StartRidingTrigger$TriggerInstance;
+			ARG 0 player

--- a/data/net/minecraft/advancements/critereon/StatePropertiesPredicate.mapping
+++ b/data/net/minecraft/advancements/critereon/StatePropertiesPredicate.mapping
@@ -1,14 +1,16 @@
 CLASS net/minecraft/advancements/critereon/StatePropertiesPredicate
 	METHOD checkState (Lnet/minecraft/world/level/block/state/StateDefinition;Ljava/util/function/Consumer;)V
 		ARG 1 properties
-		ARG 2 stringConsumer
+		ARG 2 propertyConsumer
 	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/StatePropertiesPredicate;
-		ARG 0 element
+		ARG 0 json
 	METHOD fromJson (Ljava/lang/String;Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/StatePropertiesPredicate$PropertyMatcher;
 		ARG 0 name
-		ARG 1 element
+		ARG 1 json
 	METHOD getStringOrNull (Lcom/google/gson/JsonElement;)Ljava/lang/String;
-		ARG 0 element
+		ARG 0 json
+	METHOD lambda$checkState$0 (Lnet/minecraft/world/level/block/state/StateDefinition;Ljava/util/function/Consumer;Lnet/minecraft/advancements/critereon/StatePropertiesPredicate$PropertyMatcher;)V
+		ARG 2 propertyMatcher
 	METHOD matches (Lnet/minecraft/world/level/block/state/BlockState;)Z
 		ARG 1 state
 	METHOD matches (Lnet/minecraft/world/level/block/state/StateDefinition;Lnet/minecraft/world/level/block/state/StateHolder;)Z
@@ -18,22 +20,20 @@ CLASS net/minecraft/advancements/critereon/StatePropertiesPredicate
 		ARG 1 state
 	CLASS Builder
 		METHOD hasProperty (Lnet/minecraft/world/level/block/state/properties/Property;I)Lnet/minecraft/advancements/critereon/StatePropertiesPredicate$Builder;
-			ARG 1 intProp
+			ARG 1 property
 			ARG 2 value
 		METHOD hasProperty (Lnet/minecraft/world/level/block/state/properties/Property;Ljava/lang/Comparable;)Lnet/minecraft/advancements/critereon/StatePropertiesPredicate$Builder;
-			ARG 1 prop
+			ARG 1 property
 			ARG 2 value
 		METHOD hasProperty (Lnet/minecraft/world/level/block/state/properties/Property;Ljava/lang/String;)Lnet/minecraft/advancements/critereon/StatePropertiesPredicate$Builder;
 			ARG 1 property
 			ARG 2 value
 		METHOD hasProperty (Lnet/minecraft/world/level/block/state/properties/Property;Z)Lnet/minecraft/advancements/critereon/StatePropertiesPredicate$Builder;
-			ARG 1 boolProp
+			ARG 1 property
 			ARG 2 value
-	CLASS ExactPropertyMatcher
-		METHOD match (Lnet/minecraft/world/level/block/state/StateHolder;Lnet/minecraft/world/level/block/state/properties/Property;)Z
-			ARG 1 properties
-			ARG 2 propertyTarget
 	CLASS PropertyMatcher
+		METHOD <init> (Ljava/lang/String;)V
+			ARG 1 name
 		METHOD checkState (Lnet/minecraft/world/level/block/state/StateDefinition;Ljava/util/function/Consumer;)V
 			ARG 1 properties
 			ARG 2 propertyConsumer
@@ -42,8 +42,19 @@ CLASS net/minecraft/advancements/critereon/StatePropertiesPredicate
 			ARG 2 propertyToMatch
 		METHOD match (Lnet/minecraft/world/level/block/state/StateHolder;Lnet/minecraft/world/level/block/state/properties/Property;)Z
 			ARG 1 properties
+			ARG 2 property
+	CLASS ExactPropertyMatcher
+		METHOD <init> (Ljava/lang/String;Ljava/lang/String;)V
+			ARG 1 name
+			ARG 2 value
+		METHOD match (Lnet/minecraft/world/level/block/state/StateHolder;Lnet/minecraft/world/level/block/state/properties/Property;)Z
+			ARG 1 properties
 			ARG 2 propertyTarget
 	CLASS RangedPropertyMatcher
+		METHOD <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+			ARG 1 name
+			ARG 2 minValue
+			ARG 3 maxValue
 		METHOD match (Lnet/minecraft/world/level/block/state/StateHolder;Lnet/minecraft/world/level/block/state/properties/Property;)Z
 			ARG 1 properties
 			ARG 2 propertyTarget

--- a/data/net/minecraft/advancements/critereon/SummonedEntityTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/SummonedEntityTrigger.mapping
@@ -3,13 +3,18 @@ CLASS net/minecraft/advancements/critereon/SummonedEntityTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/advancements/critereon/SummonedEntityTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/Entity;)V
 		ARG 1 player
 		ARG 2 entity
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+			ARG 2 entity
 		METHOD matches (Lnet/minecraft/world/level/storage/loot/LootContext;)Z
 			ARG 1 lootContext
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions
 		METHOD summonedEntity (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;)Lnet/minecraft/advancements/critereon/SummonedEntityTrigger$TriggerInstance;
-			ARG 0 entityBuilder
+			ARG 0 entityPredicateBuilder

--- a/data/net/minecraft/advancements/critereon/TameAnimalTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/TameAnimalTrigger.mapping
@@ -3,13 +3,18 @@ CLASS net/minecraft/advancements/critereon/TameAnimalTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/advancements/critereon/TameAnimalTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/animal/Animal;)V
 		ARG 1 player
 		ARG 2 entity
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+			ARG 2 entity
 		METHOD matches (Lnet/minecraft/world/level/storage/loot/LootContext;)Z
-			ARG 1 context
+			ARG 1 lootContext
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions
 		METHOD tamedAnimal (Lnet/minecraft/advancements/critereon/EntityPredicate;)Lnet/minecraft/advancements/critereon/TameAnimalTrigger$TriggerInstance;
-			ARG 0 entityCondition
+			ARG 0 entityPredicate

--- a/data/net/minecraft/advancements/critereon/TargetBlockTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/TargetBlockTrigger.mapping
@@ -3,12 +3,18 @@ CLASS net/minecraft/advancements/critereon/TargetBlockTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/world/phys/Vec3;ILnet/minecraft/advancements/critereon/TargetBlockTrigger$TriggerInstance;)Z
+		ARG 3 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;I)V
 		ARG 1 player
 		ARG 2 projectile
 		ARG 3 vector
 		ARG 4 signalStrength
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;)V
+			ARG 1 player
+			ARG 2 signalStrength
+			ARG 3 projectile
 		METHOD matches (Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/world/phys/Vec3;I)Z
 			ARG 1 context
 			ARG 2 vector

--- a/data/net/minecraft/advancements/critereon/TradeTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/TradeTrigger.mapping
@@ -8,6 +8,10 @@ CLASS net/minecraft/advancements/critereon/TradeTrigger
 		ARG 2 villager
 		ARG 3 stack
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+			ARG 1 player
+			ARG 2 villager
+			ARG 3 item
 		METHOD matches (Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/world/item/ItemStack;)Z
 			ARG 1 context
 			ARG 2 stack

--- a/data/net/minecraft/advancements/critereon/TradeTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/TradeTrigger.mapping
@@ -3,6 +3,8 @@ CLASS net/minecraft/advancements/critereon/TradeTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/level/storage/loot/LootContext;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/advancements/critereon/TradeTrigger$TriggerInstance;)Z
+		ARG 2 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/entity/npc/AbstractVillager;Lnet/minecraft/world/item/ItemStack;)V
 		ARG 1 player
 		ARG 2 villager

--- a/data/net/minecraft/advancements/critereon/UsedEnderEyeTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/UsedEnderEyeTrigger.mapping
@@ -3,9 +3,14 @@ CLASS net/minecraft/advancements/critereon/UsedEnderEyeTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (DLnet/minecraft/advancements/critereon/UsedEnderEyeTrigger$TriggerInstance;)Z
+		ARG 2 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;)V
 		ARG 1 player
 		ARG 2 pos
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/MinMaxBounds$Doubles;)V
+			ARG 1 player
+			ARG 2 level
 		METHOD matches (D)Z
 			ARG 1 distanceSq

--- a/data/net/minecraft/advancements/critereon/UsedTotemTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/UsedTotemTrigger.mapping
@@ -3,13 +3,20 @@ CLASS net/minecraft/advancements/critereon/UsedTotemTrigger
 		ARG 1 json
 		ARG 2 entityPredicate
 		ARG 3 conditionsParser
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/advancements/critereon/UsedTotemTrigger$TriggerInstance;)Z
+		ARG 1 instance
 	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;)V
 		ARG 1 player
 		ARG 2 item
 	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+			ARG 1 player
+			ARG 2 item
 		METHOD matches (Lnet/minecraft/world/item/ItemStack;)Z
 			ARG 1 item
 		METHOD serializeToJson (Lnet/minecraft/advancements/critereon/SerializationContext;)Lcom/google/gson/JsonObject;
 			ARG 1 conditions
+		METHOD usedTotem (Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/UsedTotemTrigger$TriggerInstance;
+			ARG 0 item
 		METHOD usedTotem (Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/advancements/critereon/UsedTotemTrigger$TriggerInstance;
 			ARG 0 item

--- a/data/net/minecraft/advancements/critereon/UsingItemTrigger.mapping
+++ b/data/net/minecraft/advancements/critereon/UsingItemTrigger.mapping
@@ -1,0 +1,15 @@
+CLASS net/minecraft/advancements/critereon/UsingItemTrigger
+	METHOD lambda$trigger$0 (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/advancements/critereon/UsingItemTrigger$TriggerInstance;)Z
+		ARG 1 instance
+	METHOD trigger (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/item/ItemStack;)V
+		ARG 1 player
+		ARG 2 item
+	CLASS TriggerInstance
+		METHOD <init> (Lnet/minecraft/advancements/critereon/EntityPredicate$Composite;Lnet/minecraft/advancements/critereon/ItemPredicate;)V
+			ARG 1 player
+			ARG 2 item
+		METHOD lookingAt (Lnet/minecraft/advancements/critereon/EntityPredicate$Builder;Lnet/minecraft/advancements/critereon/ItemPredicate$Builder;)Lnet/minecraft/advancements/critereon/UsingItemTrigger$TriggerInstance;
+			ARG 0 entityPredicateBuilder
+			ARG 1 itemPredicateBuilder
+		METHOD matches (Lnet/minecraft/world/item/ItemStack;)Z
+			ARG 1 item

--- a/data/net/minecraft/advancements/critereon/WrappedMinMaxBounds.mapping
+++ b/data/net/minecraft/advancements/critereon/WrappedMinMaxBounds.mapping
@@ -1,14 +1,37 @@
 CLASS net/minecraft/advancements/critereon/WrappedMinMaxBounds
+	METHOD <init> (Ljava/lang/Float;Ljava/lang/Float;)V
+		ARG 1 min
+		ARG 2 max
+	METHOD atLeast (F)Lnet/minecraft/advancements/critereon/WrappedMinMaxBounds;
+		ARG 0 min
+	METHOD atMost (F)Lnet/minecraft/advancements/critereon/WrappedMinMaxBounds;
+		ARG 0 max
+	METHOD between (FF)Lnet/minecraft/advancements/critereon/WrappedMinMaxBounds;
+		ARG 0 min
+		ARG 1 max
+	METHOD exactly (F)Lnet/minecraft/advancements/critereon/WrappedMinMaxBounds;
+		ARG 0 value
+	METHOD fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/advancements/critereon/WrappedMinMaxBounds;
+		ARG 0 json
+	METHOD fromReader (Lcom/mojang/brigadier/StringReader;Z)Lnet/minecraft/advancements/critereon/WrappedMinMaxBounds;
+		ARG 0 reader
+		ARG 1 isFloatingPoint
 	METHOD fromReader (Lcom/mojang/brigadier/StringReader;ZLjava/util/function/Function;)Lnet/minecraft/advancements/critereon/WrappedMinMaxBounds;
 		ARG 0 reader
 		ARG 1 isFloatingPoint
-		ARG 2 valueFunction
+		ARG 2 valueFactory
 	METHOD isAllowedNumber (Lcom/mojang/brigadier/StringReader;Z)Z
 		ARG 0 reader
 		ARG 1 isFloatingPoint
+	METHOD lambda$fromReader$0 (Ljava/lang/Float;)Ljava/lang/Float;
+		ARG 0 value
+	METHOD matches (F)Z
+		ARG 1 value
+	METHOD matchesSqr (D)Z
+		ARG 1 value
 	METHOD optionallyFormat (Ljava/lang/Float;Ljava/util/function/Function;)Ljava/lang/Float;
 		ARG 0 value
-		ARG 1 valueFunction
+		ARG 1 valueFactory
 	METHOD readNumber (Lcom/mojang/brigadier/StringReader;Z)Ljava/lang/Float;
 		ARG 0 reader
 		ARG 1 isFloatingPoint


### PR DESCRIPTION
Fixing mcp cruft. Notable changes:
- Removed / rewrote exceedingly pedantic or redundant javadocs. (No it is not useful to have an `@code` doc containing the entire contents of the method... just why)
- Lots of incidental parameter names where they matched field names
- Standardization across the board.