### PR TITLE
Fix parameter name offsets in ClientboundCommandsPacket.mapping

### DIFF
--- a/data/net/minecraft/network/protocol/game/ClientboundCommandsPacket.mapping
+++ b/data/net/minecraft/network/protocol/game/ClientboundCommandsPacket.mapping
@@ -5,8 +5,7 @@ CLASS net/minecraft/network/protocol/game/ClientboundCommandsPacket
 		ARG 1 buffer
 	METHOD createBuilder (Lnet/minecraft/network/FriendlyByteBuf;B)Lcom/mojang/brigadier/builder/ArgumentBuilder;
 		ARG 0 buffer
-		ARG 1 buffer
-		ARG 2 flags
+		ARG 1 flags
 	METHOD enumerateNodes (Lcom/mojang/brigadier/tree/RootCommandNode;)Lit/unimi/dsi/fastutil/objects/Object2IntMap;
 		ARG 0 rootNode
 	METHOD getNodesInIdOrder (Lit/unimi/dsi/fastutil/objects/Object2IntMap;)Ljava/util/List;
@@ -16,7 +15,6 @@ CLASS net/minecraft/network/protocol/game/ClientboundCommandsPacket
 		ARG 1 handler
 	METHOD readNode (Lnet/minecraft/network/FriendlyByteBuf;)Lnet/minecraft/network/protocol/game/ClientboundCommandsPacket$Entry;
 		ARG 0 buffer
-		ARG 1 buffer
 	METHOD resolveEntries (Ljava/util/List;)V
 		ARG 0 entries
 	METHOD write (Lnet/minecraft/network/FriendlyByteBuf;)V
@@ -24,9 +22,8 @@ CLASS net/minecraft/network/protocol/game/ClientboundCommandsPacket
 		ARG 1 buffer
 	METHOD writeNode (Lnet/minecraft/network/FriendlyByteBuf;Lcom/mojang/brigadier/tree/CommandNode;Ljava/util/Map;)V
 		ARG 0 buffer
-		ARG 1 buffer
-		ARG 2 node
-		ARG 3 nodeIds
+		ARG 1 node
+		ARG 2 nodeIds
 	CLASS Entry
 		METHOD <init> (Lcom/mojang/brigadier/builder/ArgumentBuilder;BI[I)V
 			ARG 1 builder


### PR DESCRIPTION
This is another case where there was an extra parameter in a method, which threw things off. It slipped through the radar with my previous network PR, sorry.