### PR TITLE
[1.17.x] Update Compass and enable blackstone in exports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,8 +109,9 @@ tasks.register('enigma', EnigmaExec) {
 }
 
 tasks.withType(GenerateExport) {
-    // Disable if UPDATING is set. This will ensure cascaded method data does not get mixed into the production data when updating.
-    useBlackstone = project.hasProperty('UPDATING')
+    // Disable blackstone if UPDATING is set.
+    // This will ensure cascaded method data does not get mixed into the production data when updating.
+    useBlackstone = !Boolean.valueOf(project.findProperty('UPDATING')?.toString())
 }
 
 tasks.register('generateSanitizedExport', GenerateSanitizedExport) {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 plugins {
-    id 'org.parchmentmc.compass' version '0.3.2'
+    id 'org.parchmentmc.compass' version '0.3.3'
     id 'org.parchmentmc.writtenbooks' version '0.5.+'
     id 'maven-publish'
     id 'java-base'
@@ -106,6 +106,10 @@ def remapJar = tasks.register('remapJar', RemapJar) {
 tasks.register('enigma', EnigmaExec) {
     inputJar = remapJar.flatMap { it.outputJar }
     mappings = project.compass.productionData
+}
+
+tasks.withType(GenerateExport) {
+    useBlackstone = true
 }
 
 tasks.register('generateSanitizedExport', GenerateSanitizedExport) {

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,8 @@ tasks.register('enigma', EnigmaExec) {
 }
 
 tasks.withType(GenerateExport) {
-    useBlackstone = true
+    // Disable if UPDATING is set. This will ensure cascaded method data does not get mixed into the production data when updating.
+    useBlackstone = project.hasProperty('UPDATING')
 }
 
 tasks.register('generateSanitizedExport', GenerateSanitizedExport) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# Blackstone requires a good chunk of memory to parse and hold.
+# This ensures gradle doesn't run out of memory and should speed up exports as it doesn't have to GC as often.
+org.gradle.jvmargs=-Xmx1G

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR is waiting on release `0.3.3` of Compass before it can be merged.

This PR updates Compass and enables the usage of blackstone in all `GenerateExport` tasks. With blackstone enabled, the new cascading method data feature can be utilized. JVM args have been added to `gradle.properties` increasing the maximum memory consumption to account for Blackstone and its large memory footprint.