### PR TITLE
Fix incorrect 'recipeName' parameters in RecipeProvider

### DIFF
--- a/data/net/minecraft/data/recipes/RecipeProvider.mapping
+++ b/data/net/minecraft/data/recipes/RecipeProvider.mapping
@@ -140,12 +140,12 @@ CLASS net/minecraft/data/recipes/RecipeProvider
 		ARG 0 finishedRecipeConsumer
 		ARG 1 result
 		ARG 2 ingredient
-		ARG 3 recipeName
+		ARG 3 group
 	METHOD oneToOneConversionRecipe (Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;Ljava/lang/String;I)V
 		ARG 0 finishedRecipeConsumer
 		ARG 1 result
 		ARG 2 ingredient
-		ARG 3 recipeName
+		ARG 3 group
 		ARG 4 resultCount
 	METHOD oreBlasting (Ljava/util/function/Consumer;Ljava/util/List;Lnet/minecraft/world/level/ItemLike;FILjava/lang/String;)V
 		ARG 0 finishedRecipeConsumer
@@ -153,7 +153,7 @@ CLASS net/minecraft/data/recipes/RecipeProvider
 		ARG 2 result
 		ARG 3 experience
 		ARG 4 cookingTime
-		ARG 5 recipeName
+		ARG 5 group
 	METHOD oreCooking (Ljava/util/function/Consumer;Lnet/minecraft/world/item/crafting/SimpleCookingSerializer;Ljava/util/List;Lnet/minecraft/world/level/ItemLike;FILjava/lang/String;Ljava/lang/String;)V
 		ARG 0 finishedRecipeConsumer
 		ARG 1 cookingSerializer
@@ -169,7 +169,7 @@ CLASS net/minecraft/data/recipes/RecipeProvider
 		ARG 2 result
 		ARG 3 experience
 		ARG 4 cookingTime
-		ARG 5 recipeName
+		ARG 5 group
 	METHOD planksFromLog (Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/tags/Tag;)V
 		ARG 0 finishedRecipeConsumer
 		ARG 1 planks


### PR DESCRIPTION
As evidenced by the implementation of the oreCooking method on line 157 in the mappings, the other methods that call this one actually take the 'group' rather than the recipe name as parameters.