### PR TITLE
Phoenix: levelgen/feature/structure, levelgen/structure/*

### DIFF
--- a/data/net/minecraft/world/level/levelgen/feature/structures/EmptyPoolElement.mapping
+++ b/data/net/minecraft/world/level/levelgen/feature/structures/EmptyPoolElement.mapping
@@ -1,10 +1,1 @@
 CLASS net/minecraft/world/level/levelgen/feature/structures/EmptyPoolElement
-	METHOD getBoundingBox (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/BoundingBox;
-		ARG 1 templateManager
-		ARG 2 pos
-		ARG 3 rotation
-	METHOD getShuffledJigsawBlocks (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;Ljava/util/Random;)Ljava/util/List;
-		ARG 1 templateManager
-		ARG 2 pos
-		ARG 3 rotation
-		ARG 4 random

--- a/data/net/minecraft/world/level/levelgen/feature/structures/EmptyPoolElement.mapping
+++ b/data/net/minecraft/world/level/levelgen/feature/structures/EmptyPoolElement.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/world/level/levelgen/feature/structures/EmptyPoolElement

--- a/data/net/minecraft/world/level/levelgen/feature/structures/FeaturePoolElement.mapping
+++ b/data/net/minecraft/world/level/levelgen/feature/structures/FeaturePoolElement.mapping
@@ -2,12 +2,3 @@ CLASS net/minecraft/world/level/levelgen/feature/structures/FeaturePoolElement
 	METHOD <init> (Ljava/util/function/Supplier;Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)V
 		ARG 1 feature
 		ARG 2 projection
-	METHOD getBoundingBox (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/BoundingBox;
-		ARG 1 templateManager
-		ARG 2 pos
-		ARG 3 rotation
-	METHOD getShuffledJigsawBlocks (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;Ljava/util/Random;)Ljava/util/List;
-		ARG 1 templateManager
-		ARG 2 pos
-		ARG 3 rotation
-		ARG 4 random

--- a/data/net/minecraft/world/level/levelgen/feature/structures/JigsawJunction.mapping
+++ b/data/net/minecraft/world/level/levelgen/feature/structures/JigsawJunction.mapping
@@ -5,5 +5,9 @@ CLASS net/minecraft/world/level/levelgen/feature/structures/JigsawJunction
 		ARG 3 sourceZ
 		ARG 4 deltaY
 		ARG 5 destProjection
+	METHOD deserialize (Lcom/mojang/serialization/Dynamic;)Lnet/minecraft/world/level/levelgen/feature/structures/JigsawJunction;
+		ARG 0 dynamic
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 other
+	METHOD serialize (Lcom/mojang/serialization/DynamicOps;)Lcom/mojang/serialization/Dynamic;
+		ARG 1 ops

--- a/data/net/minecraft/world/level/levelgen/feature/structures/JigsawPlacement.mapping
+++ b/data/net/minecraft/world/level/levelgen/feature/structures/JigsawPlacement.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/levelgen/feature/structures/JigsawPlacement
 	METHOD addPieces (Lnet/minecraft/core/RegistryAccess;Lnet/minecraft/world/level/levelgen/feature/configurations/JigsawConfiguration;Lnet/minecraft/world/level/levelgen/feature/structures/JigsawPlacement$PieceFactory;Lnet/minecraft/world/level/chunk/ChunkGenerator;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/levelgen/structure/StructurePieceAccessor;Ljava/util/Random;ZZLnet/minecraft/world/level/LevelHeightAccessor;)V
-		ARG 0 registry
+		ARG 0 registryAccess
 		ARG 1 config
 		ARG 2 factory
 		ARG 3 chunkGenerator
@@ -10,7 +10,7 @@ CLASS net/minecraft/world/level/levelgen/feature/structures/JigsawPlacement
 		ARG 7 random
 		ARG 10 level
 	METHOD addPieces (Lnet/minecraft/core/RegistryAccess;Lnet/minecraft/world/level/levelgen/structure/PoolElementStructurePiece;ILnet/minecraft/world/level/levelgen/feature/structures/JigsawPlacement$PieceFactory;Lnet/minecraft/world/level/chunk/ChunkGenerator;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Ljava/util/List;Ljava/util/Random;Lnet/minecraft/world/level/LevelHeightAccessor;)V
-		ARG 0 registry
+		ARG 0 registryAccess
 		ARG 1 piece
 		ARG 2 maxDepth
 		ARG 3 factory

--- a/data/net/minecraft/world/level/levelgen/feature/structures/ListPoolElement.mapping
+++ b/data/net/minecraft/world/level/levelgen/feature/structures/ListPoolElement.mapping
@@ -2,16 +2,5 @@ CLASS net/minecraft/world/level/levelgen/feature/structures/ListPoolElement
 	METHOD <init> (Ljava/util/List;Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)V
 		ARG 1 elements
 		ARG 2 projection
-	METHOD getBoundingBox (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/BoundingBox;
-		ARG 1 templateManager
-		ARG 2 pos
-		ARG 3 rotation
-	METHOD getShuffledJigsawBlocks (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;Ljava/util/Random;)Ljava/util/List;
-		ARG 1 templateManager
-		ARG 2 pos
-		ARG 3 rotation
-		ARG 4 random
-	METHOD setProjection (Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)Lnet/minecraft/world/level/levelgen/feature/structures/StructurePoolElement;
-		ARG 1 decoratorBehaviour
 	METHOD setProjectionOnEachElement (Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)V
 		ARG 1 projection

--- a/data/net/minecraft/world/level/levelgen/feature/structures/SinglePoolElement.mapping
+++ b/data/net/minecraft/world/level/levelgen/feature/structures/SinglePoolElement.mapping
@@ -5,10 +5,6 @@ CLASS net/minecraft/world/level/levelgen/feature/structures/SinglePoolElement
 		ARG 3 projection
 	METHOD <init> (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate;)V
 		ARG 1 template
-	METHOD getBoundingBox (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/BoundingBox;
-		ARG 1 templateManager
-		ARG 2 pos
-		ARG 3 rotation
 	METHOD getDataMarkers (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;Z)Ljava/util/List;
 		ARG 1 structureManager
 		ARG 2 pos
@@ -16,10 +12,6 @@ CLASS net/minecraft/world/level/levelgen/feature/structures/SinglePoolElement
 	METHOD getSettings (Lnet/minecraft/world/level/block/Rotation;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Z)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
 		ARG 1 rotation
 		ARG 2 boundingBox
-	METHOD getShuffledJigsawBlocks (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;Ljava/util/Random;)Ljava/util/List;
-		ARG 1 templateManager
-		ARG 2 pos
-		ARG 3 rotation
-		ARG 4 random
+		ARG 3 keepJigsaws
 	METHOD getTemplate (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate;
 		ARG 1 structureManager

--- a/data/net/minecraft/world/level/levelgen/feature/structures/StructurePoolElement.mapping
+++ b/data/net/minecraft/world/level/levelgen/feature/structures/StructurePoolElement.mapping
@@ -1,12 +1,14 @@
 CLASS net/minecraft/world/level/levelgen/feature/structures/StructurePoolElement
 	METHOD <init> (Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)V
 		ARG 1 projection
+	METHOD feature (Lnet/minecraft/world/level/levelgen/feature/ConfiguredFeature;)Ljava/util/function/Function;
+		ARG 0 feature
 	METHOD getBoundingBox (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/BoundingBox;
-		ARG 1 templateManager
+		ARG 1 structureManager
 		ARG 2 pos
 		ARG 3 rotation
 	METHOD getShuffledJigsawBlocks (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;Ljava/util/Random;)Ljava/util/List;
-		ARG 1 templateManager
+		ARG 1 structureManager
 		ARG 2 pos
 		ARG 3 rotation
 		ARG 4 random
@@ -19,5 +21,44 @@ CLASS net/minecraft/world/level/levelgen/feature/structures/StructurePoolElement
 		ARG 3 pos
 		ARG 4 rotation
 		ARG 5 random
+		ARG 6 box
+	METHOD lambda$empty$0 (Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)Lnet/minecraft/world/level/levelgen/feature/structures/EmptyPoolElement;
+		ARG 0 projection
+	METHOD lambda$feature$10 (Lnet/minecraft/world/level/levelgen/feature/ConfiguredFeature;Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)Lnet/minecraft/world/level/levelgen/feature/structures/FeaturePoolElement;
+		ARG 1 projection
+	METHOD lambda$legacy$2 (Ljava/lang/String;Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)Lnet/minecraft/world/level/levelgen/feature/structures/LegacySinglePoolElement;
+		ARG 1 projection
+	METHOD lambda$legacy$4 (Ljava/lang/String;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureProcessorList;Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)Lnet/minecraft/world/level/levelgen/feature/structures/LegacySinglePoolElement;
+		ARG 2 projection
+	METHOD lambda$list$11 (Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;Ljava/util/function/Function;)Lnet/minecraft/world/level/levelgen/feature/structures/StructurePoolElement;
+		ARG 1 element
+	METHOD lambda$list$12 (Ljava/util/List;Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)Lnet/minecraft/world/level/levelgen/feature/structures/ListPoolElement;
+		ARG 1 projection
+	METHOD lambda$single$6 (Ljava/lang/String;Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)Lnet/minecraft/world/level/levelgen/feature/structures/SinglePoolElement;
+		ARG 1 projection
+	METHOD lambda$single$8 (Ljava/lang/String;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureProcessorList;Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)Lnet/minecraft/world/level/levelgen/feature/structures/SinglePoolElement;
+		ARG 2 projection
+	METHOD legacy (Ljava/lang/String;)Ljava/util/function/Function;
+		ARG 0 key
+	METHOD legacy (Ljava/lang/String;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureProcessorList;)Ljava/util/function/Function;
+		ARG 0 key
+		ARG 1 processors
+	METHOD list (Ljava/util/List;)Ljava/util/function/Function;
+		ARG 0 elements
+	METHOD place (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureManager;Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/StructureFeatureManager;Lnet/minecraft/world/level/chunk/ChunkGenerator;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Rotation;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Ljava/util/Random;Z)Z
+		ARG 1 structureManager
+		ARG 2 level
+		ARG 3 structureFeatureManager
+		ARG 4 generator
+		ARG 5 pos
+		ARG 7 rotation
+		ARG 8 box
+		ARG 9 random
+		ARG 10 keepJigsaws
 	METHOD setProjection (Lnet/minecraft/world/level/levelgen/feature/structures/StructureTemplatePool$Projection;)Lnet/minecraft/world/level/levelgen/feature/structures/StructurePoolElement;
 		ARG 1 projection
+	METHOD single (Ljava/lang/String;)Ljava/util/function/Function;
+		ARG 0 key
+	METHOD single (Ljava/lang/String;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureProcessorList;)Ljava/util/function/Function;
+		ARG 0 key
+		ARG 1 processors

--- a/data/net/minecraft/world/level/levelgen/structure/BoundingBox.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/BoundingBox.mapping
@@ -55,7 +55,7 @@ CLASS net/minecraft/world/level/levelgen/structure/BoundingBox
 		COMMENT @return {@code true} if the bounding box contains the {@code vector}.
 		ARG 1 vector
 	METHOD lambda$static$1 (Ljava/util/stream/IntStream;)Lcom/mojang/serialization/DataResult;
-		ARG 0 steam
+		ARG 0 stream
 	METHOD move (III)Lnet/minecraft/world/level/levelgen/structure/BoundingBox;
 		COMMENT Translates this box by the given coordinates, modifying the current box.
 		ARG 1 x

--- a/data/net/minecraft/world/level/levelgen/structure/BoundingBox.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/BoundingBox.mapping
@@ -54,6 +54,8 @@ CLASS net/minecraft/world/level/levelgen/structure/BoundingBox
 	METHOD isInside (Lnet/minecraft/core/Vec3i;)Z
 		COMMENT @return {@code true} if the bounding box contains the {@code vector}.
 		ARG 1 vector
+	METHOD lambda$static$1 (Ljava/util/stream/IntStream;)Lcom/mojang/serialization/DataResult;
+		ARG 0 steam
 	METHOD move (III)Lnet/minecraft/world/level/levelgen/structure/BoundingBox;
 		COMMENT Translates this box by the given coordinates, modifying the current box.
 		ARG 1 x

--- a/data/net/minecraft/world/level/levelgen/structure/EndCityPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/EndCityPieces.mapping
@@ -32,12 +32,6 @@ CLASS net/minecraft/world/level/levelgen/structure/EndCityPieces
 			ARG 2 name
 			ARG 3 pos
 			ARG 4 rotation
-		METHOD handleDataMarker (Ljava/lang/String;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/ServerLevelAccessor;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
-			ARG 1 function
-			ARG 2 pos
-			ARG 3 level
-			ARG 4 random
-			ARG 5 sbb
 		METHOD makeResourceLocation (Ljava/lang/String;)Lnet/minecraft/resources/ResourceLocation;
 			ARG 0 name
 		METHOD makeSettings (ZLnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;

--- a/data/net/minecraft/world/level/levelgen/structure/IglooPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/IglooPieces.mapping
@@ -15,12 +15,6 @@ CLASS net/minecraft/world/level/levelgen/structure/IglooPieces
 			ARG 3 pos
 			ARG 4 rotation
 			ARG 5 down
-		METHOD handleDataMarker (Ljava/lang/String;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/ServerLevelAccessor;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
-			ARG 1 function
-			ARG 2 pos
-			ARG 3 level
-			ARG 4 random
-			ARG 5 sbb
 		METHOD makePosition (Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/core/BlockPos;I)Lnet/minecraft/core/BlockPos;
 			ARG 0 location
 			ARG 1 pos

--- a/data/net/minecraft/world/level/levelgen/structure/JunglePyramidPiece.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/JunglePyramidPiece.mapping
@@ -6,4 +6,3 @@ CLASS net/minecraft/world/level/levelgen/structure/JunglePyramidPiece
 	METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 		ARG 1 level
 		ARG 2 tag
-	CLASS MossStoneSelector

--- a/data/net/minecraft/world/level/levelgen/structure/JunglePyramidPiece.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/JunglePyramidPiece.mapping
@@ -7,10 +7,3 @@ CLASS net/minecraft/world/level/levelgen/structure/JunglePyramidPiece
 		ARG 1 level
 		ARG 2 tag
 	CLASS MossStoneSelector
-		METHOD next (Ljava/util/Random;IIIZ)V
-			COMMENT picks Block Ids and Metadata (Silverfish)
-			ARG 1 random
-			ARG 2 x
-			ARG 3 y
-			ARG 4 z
-			ARG 5 wall

--- a/data/net/minecraft/world/level/levelgen/structure/LegacyStructureDataHandler.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/LegacyStructureDataHandler.mapping
@@ -13,10 +13,14 @@ CLASS net/minecraft/world/level/levelgen/structure/LegacyStructureDataHandler
 	METHOD isUnhandledStructureStart (II)Z
 		ARG 1 chunkX
 		ARG 2 chunkZ
+	METHOD lambda$static$0 (Ljava/util/HashMap;)V
+		ARG 0 map
+	METHOD lambda$static$1 (Ljava/util/HashMap;)V
+		ARG 0 map
 	METHOD populateCaches (Lnet/minecraft/world/level/storage/DimensionDataStorage;)V
 		ARG 1 storage
 	METHOD removeIndex (J)V
-		ARG 1 chunkValue
+		ARG 1 packedChunkPos
 	METHOD updateFromLegacy (Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/nbt/CompoundTag;
 		ARG 1 tag
 	METHOD updateStructureStart (Lnet/minecraft/nbt/CompoundTag;Lnet/minecraft/world/level/ChunkPos;)Lnet/minecraft/nbt/CompoundTag;

--- a/data/net/minecraft/world/level/levelgen/structure/MineShaftPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/MineShaftPieces.mapping
@@ -27,10 +27,6 @@ CLASS net/minecraft/world/level/levelgen/structure/MineShaftPieces
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
 			ARG 2 tag
-		METHOD move (III)V
-			ARG 1 x
-			ARG 2 y
-			ARG 3 z
 	CLASS MineShaftPiece
 		METHOD <init> (Lnet/minecraft/world/level/levelgen/feature/StructurePieceType;ILnet/minecraft/world/level/levelgen/feature/MineshaftFeature$Type;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
 			ARG 1 pieceType
@@ -42,7 +38,7 @@ CLASS net/minecraft/world/level/levelgen/structure/MineShaftPieces
 			ARG 2 box
 		METHOD isSupportingBox (Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;IIII)Z
 			ARG 1 level
-			ARG 2 bounds
+			ARG 2 box
 			ARG 3 xStart
 			ARG 4 xEnd
 			ARG 5 y
@@ -86,24 +82,15 @@ CLASS net/minecraft/world/level/levelgen/structure/MineShaftPieces
 			ARG 3 state
 		METHOD canPlaceColumnOnTopOf (Lnet/minecraft/world/level/block/state/BlockState;)Z
 			ARG 1 state
-		METHOD createChest (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Ljava/util/Random;IIILnet/minecraft/resources/ResourceLocation;)Z
-			COMMENT Adds chest to the structure and sets its contents
-			ARG 1 level
-			ARG 2 structurebb
-			ARG 3 random
-			ARG 4 x
-			ARG 5 y
-			ARG 6 z
-			ARG 7 loot
 		METHOD fillColumnBetween (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos$MutableBlockPos;II)V
 			ARG 0 level
-			ARG 1 fillerBlock
+			ARG 1 state
 			ARG 2 pos
 			ARG 3 minY
 			ARG 4 maxY
 		METHOD fillPillarDownOrChainUp (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/block/state/BlockState;IIILnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
 			ARG 1 level
-			ARG 2 defaultBlock
+			ARG 2 state
 			ARG 3 x
 			ARG 4 y
 			ARG 5 z
@@ -121,6 +108,7 @@ CLASS net/minecraft/world/level/levelgen/structure/MineShaftPieces
 			ARG 3 x
 			ARG 4 y
 			ARG 5 z
+			ARG 6 required
 		METHOD maybePlaceCobWeb (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Ljava/util/Random;FIII)V
 			ARG 1 level
 			ARG 2 box

--- a/data/net/minecraft/world/level/levelgen/structure/NetherBridgePieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/NetherBridgePieces.mapping
@@ -163,24 +163,28 @@ CLASS net/minecraft/world/level/levelgen/structure/NetherBridgePieces
 			ARG 6 z
 			ARG 7 orientation
 			ARG 8 genDepth
+			ARG 9 castlePiece
 		METHOD generateChildForward (Lnet/minecraft/world/level/levelgen/structure/NetherBridgePieces$StartPiece;Lnet/minecraft/world/level/levelgen/structure/StructurePieceAccessor;Ljava/util/Random;IIZ)Lnet/minecraft/world/level/levelgen/structure/StructurePiece;
 			ARG 1 startPiece
 			ARG 2 pieces
 			ARG 3 random
 			ARG 4 offsetX
 			ARG 5 offsetY
+			ARG 6 castlePiece
 		METHOD generateChildLeft (Lnet/minecraft/world/level/levelgen/structure/NetherBridgePieces$StartPiece;Lnet/minecraft/world/level/levelgen/structure/StructurePieceAccessor;Ljava/util/Random;IIZ)Lnet/minecraft/world/level/levelgen/structure/StructurePiece;
 			ARG 1 startPiece
 			ARG 2 pieces
 			ARG 3 random
 			ARG 4 offsetY
 			ARG 5 offsetX
+			ARG 6 castlePiece
 		METHOD generateChildRight (Lnet/minecraft/world/level/levelgen/structure/NetherBridgePieces$StartPiece;Lnet/minecraft/world/level/levelgen/structure/StructurePieceAccessor;Ljava/util/Random;IIZ)Lnet/minecraft/world/level/levelgen/structure/StructurePiece;
 			ARG 1 startPiece
 			ARG 2 pieces
 			ARG 3 random
 			ARG 4 offsetY
 			ARG 5 offsetX
+			ARG 6 castlePiece
 		METHOD generatePiece (Lnet/minecraft/world/level/levelgen/structure/NetherBridgePieces$StartPiece;Ljava/util/List;Lnet/minecraft/world/level/levelgen/structure/StructurePieceAccessor;Ljava/util/Random;IIILnet/minecraft/core/Direction;I)Lnet/minecraft/world/level/levelgen/structure/NetherBridgePieces$NetherBridgePiece;
 			ARG 1 startPiece
 			ARG 2 weights
@@ -192,7 +196,6 @@ CLASS net/minecraft/world/level/levelgen/structure/NetherBridgePieces
 			ARG 8 orientation
 			ARG 9 genDepth
 		METHOD isOkBox (Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)Z
-			COMMENT Checks if the bounding box's minY is > 10
 			ARG 0 box
 		METHOD updatePieceWeight (Ljava/util/List;)I
 			ARG 1 weights

--- a/data/net/minecraft/world/level/levelgen/structure/NetherFossilPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/NetherFossilPieces.mapping
@@ -13,11 +13,5 @@ CLASS net/minecraft/world/level/levelgen/structure/NetherFossilPieces
 			ARG 2 location
 			ARG 3 pos
 			ARG 4 rotation
-		METHOD handleDataMarker (Ljava/lang/String;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/ServerLevelAccessor;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
-			ARG 1 function
-			ARG 2 pos
-			ARG 3 level
-			ARG 4 random
-			ARG 5 sbb
 		METHOD makeSettings (Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
 			ARG 0 rotation

--- a/data/net/minecraft/world/level/levelgen/structure/OceanMonumentPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/OceanMonumentPieces.mapping
@@ -1,16 +1,8 @@
 CLASS net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
 	CLASS FitSimpleRoom
-		METHOD fits (Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)Z
-			ARG 1 definition
 	CLASS FitDoubleXRoom
-		METHOD fits (Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)Z
-			ARG 1 definition
 	CLASS FitDoubleYRoom
-		METHOD fits (Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)Z
-			ARG 1 definition
 	CLASS FitDoubleZRoom
-		METHOD fits (Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)Z
-			ARG 1 definition
 	CLASS RoomDefinition
 		METHOD <init> (I)V
 			ARG 1 index
@@ -18,16 +10,10 @@ CLASS net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
 			ARG 1 index
 		METHOD setConnection (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)V
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 connectingRoom
 	CLASS FitDoubleXYRoom
-		METHOD fits (Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)Z
-			ARG 1 definition
 	CLASS FitDoubleYZRoom
-		METHOD fits (Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)Z
-			ARG 1 definition
 	CLASS FitSimpleTopRoom
-		METHOD fits (Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)Z
-			ARG 1 definition
 	CLASS MonumentBuilding
 		METHOD <init> (Ljava/util/Random;IILnet/minecraft/core/Direction;)V
 			ARG 1 random
@@ -64,16 +50,18 @@ CLASS net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
 			ARG 2 random
 			ARG 3 box
 		METHOD generateWing (ZILnet/minecraft/world/level/WorldGenLevel;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
+			ARG 1 wing
+			ARG 2 x
 			ARG 3 level
 			ARG 4 random
 			ARG 5 box
 	CLASS MonumentRoomFitter
 		METHOD create (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;Ljava/util/Random;)Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$OceanMonumentPiece;
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 room
 			ARG 3 random
 		METHOD fits (Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)Z
-			ARG 1 definition
+			ARG 1 room
 	CLASS OceanMonumentPiece
 		METHOD <init> (Lnet/minecraft/world/level/levelgen/feature/StructurePieceType;ILnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;III)V
 			ARG 1 type
@@ -119,6 +107,10 @@ CLASS net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
 			ARG 6 x2
 			ARG 7 y2
 			ARG 8 z2
+		METHOD getRoomIndex (III)I
+			ARG 0 x
+			ARG 1 y
+			ARG 2 z
 		METHOD makeBoundingBox (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;III)Lnet/minecraft/world/level/levelgen/structure/BoundingBox;
 			ARG 0 direction
 			ARG 1 definition
@@ -134,7 +126,7 @@ CLASS net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
 	CLASS OceanMonumentCoreRoom
 		METHOD <init> (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)V
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 room
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
 			ARG 2 tag
@@ -142,13 +134,14 @@ CLASS net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
 		METHOD <init> (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;I)V
 			ARG 1 direction
 			ARG 2 box
+			ARG 3 flag
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
 			ARG 2 tag
 	CLASS OceanMonumentEntryRoom
 		METHOD <init> (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)V
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 room
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
 			ARG 2 tag
@@ -162,7 +155,7 @@ CLASS net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
 	CLASS OceanMonumentSimpleRoom
 		METHOD <init> (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;Ljava/util/Random;)V
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 room
 			ARG 3 random
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
@@ -170,42 +163,42 @@ CLASS net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
 	CLASS OceanMonumentDoubleXRoom
 		METHOD <init> (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)V
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 room
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
 			ARG 2 tag
 	CLASS OceanMonumentDoubleYRoom
 		METHOD <init> (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)V
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 room
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
 			ARG 2 tag
 	CLASS OceanMonumentDoubleZRoom
 		METHOD <init> (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)V
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 room
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
 			ARG 2 tag
 	CLASS OceanMonumentDoubleXYRoom
 		METHOD <init> (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)V
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 room
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
 			ARG 2 tag
 	CLASS OceanMonumentDoubleYZRoom
 		METHOD <init> (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)V
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 room
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
 			ARG 2 tag
 	CLASS OceanMonumentSimpleTopRoom
 		METHOD <init> (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)V
 			ARG 1 direction
-			ARG 2 definition
+			ARG 2 room
 		METHOD <init> (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;)V
 			ARG 1 level
 			ARG 2 tag

--- a/data/net/minecraft/world/level/levelgen/structure/OceanMonumentPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/OceanMonumentPieces.mapping
@@ -1,8 +1,4 @@
 CLASS net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
-	CLASS FitSimpleRoom
-	CLASS FitDoubleXRoom
-	CLASS FitDoubleYRoom
-	CLASS FitDoubleZRoom
 	CLASS RoomDefinition
 		METHOD <init> (I)V
 			ARG 1 index
@@ -11,9 +7,6 @@ CLASS net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
 		METHOD setConnection (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition;)V
 			ARG 1 direction
 			ARG 2 connectingRoom
-	CLASS FitDoubleXYRoom
-	CLASS FitDoubleYZRoom
-	CLASS FitSimpleTopRoom
 	CLASS MonumentBuilding
 		METHOD <init> (Ljava/util/Random;IILnet/minecraft/core/Direction;)V
 			ARG 1 random

--- a/data/net/minecraft/world/level/levelgen/structure/OceanRuinPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/OceanRuinPieces.mapping
@@ -44,11 +44,6 @@ CLASS net/minecraft/world/level/levelgen/structure/OceanRuinPieces
 		METHOD getHeight (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)I
 			ARG 1 templatePos
 			ARG 2 level
-		METHOD handleDataMarker (Ljava/lang/String;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/ServerLevelAccessor;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
-			ARG 1 function
-			ARG 2 pos
-			ARG 3 level
-			ARG 4 random
-			ARG 5 sbb
+			ARG 3 pos
 		METHOD makeSettings (Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
 			ARG 0 rotation

--- a/data/net/minecraft/world/level/levelgen/structure/PoolElementStructurePiece.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/PoolElementStructurePiece.mapping
@@ -11,10 +11,10 @@ CLASS net/minecraft/world/level/levelgen/structure/PoolElementStructurePiece
 		ARG 6 box
 	METHOD addJunction (Lnet/minecraft/world/level/levelgen/feature/structures/JigsawJunction;)V
 		ARG 1 junction
-	METHOD move (III)V
-		ARG 1 x
-		ARG 2 y
-		ARG 3 z
+	METHOD lambda$addAdditionalSaveData$2 (Lnet/minecraft/nbt/CompoundTag;Lnet/minecraft/nbt/Tag;)V
+		ARG 1 elementTag
+	METHOD lambda$new$1 (Lnet/minecraft/resources/RegistryReadOps;Lnet/minecraft/nbt/Tag;)V
+		ARG 2 junctionTag
 	METHOD place (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/StructureFeatureManager;Lnet/minecraft/world/level/chunk/ChunkGenerator;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Lnet/minecraft/core/BlockPos;Z)Z
 		ARG 1 level
 		ARG 2 structureManager

--- a/data/net/minecraft/world/level/levelgen/structure/RuinedPortalPiece.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/RuinedPortalPiece.mapping
@@ -39,12 +39,6 @@ CLASS net/minecraft/world/level/levelgen/structure/RuinedPortalPiece
 		ARG 1 x
 		ARG 2 z
 		ARG 3 placement
-	METHOD handleDataMarker (Ljava/lang/String;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/ServerLevelAccessor;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
-		ARG 1 function
-		ARG 2 pos
-		ARG 3 level
-		ARG 4 random
-		ARG 5 sbb
 	METHOD makeSettings (Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/nbt/CompoundTag;Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
 		ARG 0 level
 		ARG 1 tag

--- a/data/net/minecraft/world/level/levelgen/structure/ShipwreckPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/ShipwreckPieces.mapping
@@ -16,11 +16,5 @@ CLASS net/minecraft/world/level/levelgen/structure/ShipwreckPieces
 			ARG 3 pos
 			ARG 4 rotation
 			ARG 5 isBeached
-		METHOD handleDataMarker (Ljava/lang/String;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/ServerLevelAccessor;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
-			ARG 1 function
-			ARG 2 pos
-			ARG 3 level
-			ARG 4 random
-			ARG 5 sbb
 		METHOD makeSettings (Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
 			ARG 0 rotation

--- a/data/net/minecraft/world/level/levelgen/structure/StrongholdPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/StrongholdPieces.mapping
@@ -26,8 +26,6 @@ CLASS net/minecraft/world/level/levelgen/structure/StrongholdPieces
 		ARG 5 z
 		ARG 6 direction
 		ARG 7 genDepth
-	METHOD resetPieces ()V
-		COMMENT sets up Arrays with the Structure pieces and their weights
 	CLASS Library
 		METHOD <init> (ILjava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Lnet/minecraft/core/Direction;)V
 			ARG 1 genDepth
@@ -255,7 +253,6 @@ CLASS net/minecraft/world/level/levelgen/structure/StrongholdPieces
 			ARG 4 offsetY
 			ARG 5 offsetX
 		METHOD isOkBox (Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)Z
-			COMMENT returns false if the Structure Bounding Box goes below 10
 			ARG 0 box
 		METHOD randomSmallDoor (Ljava/util/Random;)Lnet/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece$SmallDoorType;
 			ARG 1 random
@@ -277,10 +274,3 @@ CLASS net/minecraft/world/level/levelgen/structure/StrongholdPieces
 			ARG 5 orientation
 			ARG 6 genDepth
 	CLASS SmoothStoneSelector
-		METHOD next (Ljava/util/Random;IIIZ)V
-			COMMENT picks Block Ids and Metadata (Silverfish)
-			ARG 1 random
-			ARG 2 x
-			ARG 3 y
-			ARG 4 z
-			ARG 5 wall

--- a/data/net/minecraft/world/level/levelgen/structure/StrongholdPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/StrongholdPieces.mapping
@@ -273,4 +273,3 @@ CLASS net/minecraft/world/level/levelgen/structure/StrongholdPieces
 			ARG 4 z
 			ARG 5 orientation
 			ARG 6 genDepth
-	CLASS SmoothStoneSelector

--- a/data/net/minecraft/world/level/levelgen/structure/StructureFeatureIndexSavedData.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/StructureFeatureIndexSavedData.mapping
@@ -3,14 +3,12 @@ CLASS net/minecraft/world/level/levelgen/structure/StructureFeatureIndexSavedDat
 		ARG 1 all
 		ARG 2 remaining
 	METHOD addIndex (J)V
-		ARG 1 chunkPos
+		ARG 1 index
 	METHOD hasStartIndex (J)Z
-		ARG 1 chunkPos
+		ARG 1 index
 	METHOD hasUnhandledIndex (J)Z
-		ARG 1 chunkPos
+		ARG 1 index
 	METHOD load (Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/world/level/levelgen/structure/StructureFeatureIndexSavedData;
 		ARG 0 tag
 	METHOD removeIndex (J)V
-		ARG 1 chunkPos
-	METHOD save (Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/nbt/CompoundTag;
-		ARG 1 compound
+		ARG 1 index

--- a/data/net/minecraft/world/level/levelgen/structure/StructurePiece.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/StructurePiece.mapping
@@ -27,7 +27,6 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 		ARG 5 lootTable
 		ARG 6 state
 	METHOD createChest (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Ljava/util/Random;IIILnet/minecraft/resources/ResourceLocation;)Z
-		COMMENT
 		ARG 1 level
 		ARG 2 box
 		ARG 3 random
@@ -47,7 +46,6 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 	METHOD createTag (Lnet/minecraft/server/level/ServerLevel;)Lnet/minecraft/nbt/CompoundTag;
 		ARG 1 level
 	METHOD fillColumnDown (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/block/state/BlockState;IIILnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
-		COMMENT
 		ARG 1 level
 		ARG 2 state
 		ARG 3 x
@@ -134,8 +132,6 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 		ARG 3 y
 		ARG 4 z
 		ARG 5 box
-	METHOD getGenDepth ()I
-		COMMENT
 	METHOD getRandomHorizontalDirection (Ljava/util/Random;)Lnet/minecraft/core/Direction;
 		ARG 0 random
 	METHOD getWorldPos (III)Lnet/minecraft/core/BlockPos$MutableBlockPos;
@@ -205,7 +201,6 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 		ARG 1 orientation
 	CLASS BlockSelector
 		METHOD next (Ljava/util/Random;IIIZ)V
-			COMMENT
 			ARG 1 random
 			ARG 2 x
 			ARG 3 y

--- a/data/net/minecraft/world/level/levelgen/structure/StructurePiece.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/StructurePiece.mapping
@@ -18,18 +18,18 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
-		ARG 5 boundingBox
+		ARG 5 box
 	METHOD createChest (Lnet/minecraft/world/level/ServerLevelAccessor;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Ljava/util/Random;Lnet/minecraft/core/BlockPos;Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/world/level/block/state/BlockState;)Z
 		ARG 1 level
-		ARG 2 bounds
+		ARG 2 box
 		ARG 3 random
 		ARG 4 pos
-		ARG 5 resourceLocation
+		ARG 5 lootTable
 		ARG 6 state
 	METHOD createChest (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Ljava/util/Random;IIILnet/minecraft/resources/ResourceLocation;)Z
-		COMMENT Adds chest to the structure and sets its contents
+		COMMENT
 		ARG 1 level
-		ARG 2 structurebb
+		ARG 2 box
 		ARG 3 random
 		ARG 4 x
 		ARG 5 y
@@ -37,7 +37,7 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 		ARG 7 loot
 	METHOD createDispenser (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Ljava/util/Random;IIILnet/minecraft/core/Direction;Lnet/minecraft/resources/ResourceLocation;)Z
 		ARG 1 level
-		ARG 2 sbb
+		ARG 2 box
 		ARG 3 random
 		ARG 4 x
 		ARG 5 y
@@ -47,16 +47,16 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 	METHOD createTag (Lnet/minecraft/server/level/ServerLevel;)Lnet/minecraft/nbt/CompoundTag;
 		ARG 1 level
 	METHOD fillColumnDown (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/block/state/BlockState;IIILnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
-		COMMENT Replaces air and liquid from given position downwards. Stops when hitting anything else than air or liquid
+		COMMENT
 		ARG 1 level
-		ARG 2 blockstate
+		ARG 2 state
 		ARG 3 x
 		ARG 4 y
 		ARG 5 z
-		ARG 6 boundingbox
+		ARG 6 box
 	METHOD generateAirBox (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;IIIIII)V
 		ARG 1 level
-		ARG 2 structurebb
+		ARG 2 box
 		ARG 3 minX
 		ARG 4 minY
 		ARG 5 minZ
@@ -66,7 +66,7 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 	METHOD generateBox (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;IIIIIILnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;Z)V
 		COMMENT Fill the given area with the selected blocks
 		ARG 1 level
-		ARG 2 boundingbox
+		ARG 2 box
 		ARG 3 xMin
 		ARG 4 yMin
 		ARG 5 zMin
@@ -78,7 +78,7 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 		ARG 11 existingOnly
 	METHOD generateBox (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;IIIIIIZLjava/util/Random;Lnet/minecraft/world/level/levelgen/structure/StructurePiece$BlockSelector;)V
 		ARG 1 level
-		ARG 2 boundingbox
+		ARG 2 box
 		ARG 3 minX
 		ARG 4 minY
 		ARG 5 minZ
@@ -88,6 +88,20 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 		ARG 9 alwaysReplace
 		ARG 10 random
 		ARG 11 blockselector
+	METHOD generateBox (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;Z)V
+		ARG 1 level
+		ARG 2 boundingBox
+		ARG 3 box
+		ARG 4 boundaryBlockState
+		ARG 5 insideBlockState
+		ARG 6 existingOnly
+	METHOD generateBox (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;ZLjava/util/Random;Lnet/minecraft/world/level/levelgen/structure/StructurePiece$BlockSelector;)V
+		ARG 1 level
+		ARG 2 boundingBox
+		ARG 3 box
+		ARG 4 alwaysReplace
+		ARG 5 random
+		ARG 6 selector
 	METHOD generateMaybeBox (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Ljava/util/Random;FIIIIIILnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;ZZ)V
 		ARG 1 level
 		ARG 2 sbb
@@ -105,23 +119,23 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 		ARG 14 requiredSkylight
 	METHOD generateUpperHalfSphere (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;IIIIIILnet/minecraft/world/level/block/state/BlockState;Z)V
 		ARG 1 level
-		ARG 2 boundingbox
+		ARG 2 box
 		ARG 3 minX
 		ARG 4 minY
 		ARG 5 minZ
 		ARG 6 maxX
 		ARG 7 maxY
 		ARG 8 maxZ
-		ARG 9 blockstate
+		ARG 9 state
 		ARG 10 excludeAir
 	METHOD getBlock (Lnet/minecraft/world/level/BlockGetter;IIILnet/minecraft/world/level/levelgen/structure/BoundingBox;)Lnet/minecraft/world/level/block/state/BlockState;
 		ARG 1 level
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
-		ARG 5 boundingbox
+		ARG 5 box
 	METHOD getGenDepth ()I
-		COMMENT Returns the component type ID of this component.
+		COMMENT
 	METHOD getRandomHorizontalDirection (Ljava/util/Random;)Lnet/minecraft/core/Direction;
 		ARG 0 random
 	METHOD getWorldPos (III)Lnet/minecraft/core/BlockPos$MutableBlockPos;
@@ -144,7 +158,7 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
-		ARG 5 boundingbox
+		ARG 5 box
 	METHOD isReplaceableByStructures (Lnet/minecraft/world/level/block/state/BlockState;)Z
 		ARG 1 state
 	METHOD makeBoundingBox (IIILnet/minecraft/core/Direction;III)Lnet/minecraft/world/level/levelgen/structure/BoundingBox;
@@ -157,13 +171,13 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 		ARG 6 offsetZ
 	METHOD maybeGenerateBlock (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Ljava/util/Random;FIIILnet/minecraft/world/level/block/state/BlockState;)V
 		ARG 1 level
-		ARG 2 boundingbox
+		ARG 2 box
 		ARG 3 random
 		ARG 4 chance
 		ARG 5 x
 		ARG 6 y
 		ARG 7 z
-		ARG 8 blockstate
+		ARG 8 state
 	METHOD move (III)V
 		ARG 1 x
 		ARG 2 y
@@ -178,7 +192,7 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 	METHOD postProcess (Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/StructureFeatureManager;Lnet/minecraft/world/level/chunk/ChunkGenerator;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;Lnet/minecraft/world/level/ChunkPos;Lnet/minecraft/core/BlockPos;)Z
 		ARG 1 level
 		ARG 2 structureManager
-		ARG 3 chunkGenerator
+		ARG 3 generator
 		ARG 4 random
 		ARG 5 box
 		ARG 6 chunkPos
@@ -186,12 +200,12 @@ CLASS net/minecraft/world/level/levelgen/structure/StructurePiece
 	METHOD reorient (Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/block/state/BlockState;
 		ARG 0 level
 		ARG 1 pos
-		ARG 2 blockState
+		ARG 2 state
 	METHOD setOrientation (Lnet/minecraft/core/Direction;)V
-		ARG 1 facing
+		ARG 1 orientation
 	CLASS BlockSelector
 		METHOD next (Ljava/util/Random;IIIZ)V
-			COMMENT picks Block Ids and Metadata (Silverfish)
+			COMMENT
 			ARG 1 random
 			ARG 2 x
 			ARG 3 y

--- a/data/net/minecraft/world/level/levelgen/structure/StructureStart.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/StructureStart.mapping
@@ -20,8 +20,6 @@ CLASS net/minecraft/world/level/levelgen/structure/StructureStart
 		ARG 7 level
 	METHOD isInsidePiece (Lnet/minecraft/core/BlockPos;)Z
 		ARG 1 pos
-	METHOD isValid ()Z
-		COMMENT
 	METHOD moveBelowSeaLevel (IILjava/util/Random;I)V
 		ARG 3 random
 	METHOD moveInsideHeights (Ljava/util/Random;II)V

--- a/data/net/minecraft/world/level/levelgen/structure/StructureStart.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/StructureStart.mapping
@@ -21,7 +21,7 @@ CLASS net/minecraft/world/level/levelgen/structure/StructureStart
 	METHOD isInsidePiece (Lnet/minecraft/core/BlockPos;)Z
 		ARG 1 pos
 	METHOD isValid ()Z
-		COMMENT currently only defined for Villages, returns true if Village has more than 2 non-road components
+		COMMENT
 	METHOD moveBelowSeaLevel (IILjava/util/Random;I)V
 		ARG 3 random
 	METHOD moveInsideHeights (Ljava/util/Random;II)V

--- a/data/net/minecraft/world/level/levelgen/structure/TemplateStructurePiece.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/TemplateStructurePiece.mapping
@@ -11,13 +11,10 @@ CLASS net/minecraft/world/level/levelgen/structure/TemplateStructurePiece
 		ARG 1 type
 		ARG 2 tag
 		ARG 3 level
+		ARG 4 placeSettingsFactory
 	METHOD handleDataMarker (Ljava/lang/String;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/ServerLevelAccessor;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
-		ARG 1 function
+		ARG 1 marker
 		ARG 2 pos
 		ARG 3 level
 		ARG 4 random
-		ARG 5 sbb
-	METHOD move (III)V
-		ARG 1 x
-		ARG 2 y
-		ARG 3 z
+		ARG 5 box

--- a/data/net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces.mapping
@@ -5,6 +5,8 @@ CLASS net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces
 		ARG 2 rotation
 		ARG 3 pieces
 		ARG 4 random
+	METHOD main ([Ljava/lang/String;)V
+		ARG 0 args
 	CLASS SimpleGrid
 		METHOD <init> (III)V
 			ARG 1 width
@@ -114,12 +116,6 @@ CLASS net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces
 			ARG 3 pos
 			ARG 4 rotation
 			ARG 5 mirror
-		METHOD handleDataMarker (Ljava/lang/String;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/ServerLevelAccessor;Ljava/util/Random;Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)V
-			ARG 1 function
-			ARG 2 pos
-			ARG 3 level
-			ARG 4 random
-			ARG 5 sbb
 		METHOD makeLocation (Ljava/lang/String;)Lnet/minecraft/resources/ResourceLocation;
 			ARG 0 name
 		METHOD makeSettings (Lnet/minecraft/world/level/block/Mirror;Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/AlwaysTrueTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/AlwaysTrueTest.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/world/level/levelgen/structure/templatesystem/AlwaysTrueTest

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/AlwaysTrueTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/AlwaysTrueTest.mapping
@@ -1,4 +1,1 @@
 CLASS net/minecraft/world/level/levelgen/structure/templatesystem/AlwaysTrueTest
-	METHOD test (Lnet/minecraft/world/level/block/state/BlockState;Ljava/util/Random;)Z
-		ARG 1 state
-		ARG 2 random

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/AxisAlignedLinearPosTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/AxisAlignedLinearPosTest.mapping
@@ -5,5 +5,3 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/AxisAlignedLin
 		ARG 3 minDist
 		ARG 4 maxDist
 		ARG 5 axis
-	METHOD test (Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Ljava/util/Random;)Z
-		ARG 4 random

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/BlackstoneReplaceProcessor.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/BlackstoneReplaceProcessor.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/world/level/levelgen/structure/templatesystem/BlackstoneReplaceProcessor
+	METHOD lambda$new$1 (Ljava/util/HashMap;)V
+		ARG 0 map

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/BlockAgeProcessor.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/BlockAgeProcessor.mapping
@@ -3,9 +3,11 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/BlockAgeProces
 		ARG 1 mossiness
 	METHOD getRandomBlock (Ljava/util/Random;[Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/block/state/BlockState;
 		ARG 0 random
-		ARG 1 possibleStates
+		ARG 1 states
 	METHOD getRandomBlock (Ljava/util/Random;[Lnet/minecraft/world/level/block/state/BlockState;[Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/block/state/BlockState;
 		ARG 1 random
+		ARG 2 normalStates
+		ARG 3 mossyStates
 	METHOD getRandomFacingStairs (Ljava/util/Random;Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/block/state/BlockState;
 		ARG 0 random
 		ARG 1 block

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/BlockMatchTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/BlockMatchTest.mapping
@@ -1,6 +1,3 @@
 CLASS net/minecraft/world/level/levelgen/structure/templatesystem/BlockMatchTest
 	METHOD <init> (Lnet/minecraft/world/level/block/Block;)V
 		ARG 1 block
-	METHOD test (Lnet/minecraft/world/level/block/state/BlockState;Ljava/util/Random;)Z
-		ARG 1 state
-		ARG 2 random

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/BlockRotProcessor.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/BlockRotProcessor.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/world/level/levelgen/structure/templatesystem/BlockRotProcessor
+	METHOD <init> (F)V
+		ARG 1 integrity

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/BlockStateMatchTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/BlockStateMatchTest.mapping
@@ -1,6 +1,3 @@
 CLASS net/minecraft/world/level/levelgen/structure/templatesystem/BlockStateMatchTest
 	METHOD <init> (Lnet/minecraft/world/level/block/state/BlockState;)V
 		ARG 1 blockState
-	METHOD test (Lnet/minecraft/world/level/block/state/BlockState;Ljava/util/Random;)Z
-		ARG 1 state
-		ARG 2 random

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/LinearPosTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/LinearPosTest.mapping
@@ -4,5 +4,3 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/LinearPosTest
 		ARG 2 maxChance
 		ARG 3 minDist
 		ARG 4 maxDist
-	METHOD test (Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Ljava/util/Random;)Z
-		ARG 4 random

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/PosAlwaysTrueTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/PosAlwaysTrueTest.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/world/level/levelgen/structure/templatesystem/PosAlwaysTrueTest

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/PosAlwaysTrueTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/PosAlwaysTrueTest.mapping
@@ -1,3 +1,1 @@
 CLASS net/minecraft/world/level/levelgen/structure/templatesystem/PosAlwaysTrueTest
-	METHOD test (Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Ljava/util/Random;)Z
-		ARG 4 random

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/ProcessorRule.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/ProcessorRule.mapping
@@ -20,7 +20,7 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/ProcessorRule
 		ARG 2 existingState
 			COMMENT The current state in the world.
 		ARG 3 localPos
-			COMMENT The local position of the target state, realitive to the structure origin.
+			COMMENT The local position of the target state, relative to the structure origin.
 		ARG 4 relativePos
 			COMMENT The actual position of the target state. {@code existingState} is the current in world state at this position.
 		ARG 5 structurePos

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/ProcessorRule.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/ProcessorRule.mapping
@@ -15,4 +15,14 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/ProcessorRule
 		ARG 4 outputState
 		ARG 5 outputTag
 	METHOD test (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Ljava/util/Random;)Z
+		ARG 1 inputState
+			COMMENT The incoming state from the structure.
+		ARG 2 existingState
+			COMMENT The current state in the world.
+		ARG 3 localPos
+			COMMENT The local position of the target state, realitive to the structure origin.
+		ARG 4 relativePos
+			COMMENT The actual position of the target state. {@code existingState} is the current in world state at this position.
+		ARG 5 structurePos
+			COMMENT The origin position of the structure.
 		ARG 6 random

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/RandomBlockMatchTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/RandomBlockMatchTest.mapping
@@ -2,6 +2,3 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/RandomBlockMat
 	METHOD <init> (Lnet/minecraft/world/level/block/Block;F)V
 		ARG 1 block
 		ARG 2 probability
-	METHOD test (Lnet/minecraft/world/level/block/state/BlockState;Ljava/util/Random;)Z
-		ARG 1 state
-		ARG 2 random

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/RandomBlockStateMatchTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/RandomBlockStateMatchTest.mapping
@@ -2,6 +2,3 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/RandomBlockSta
 	METHOD <init> (Lnet/minecraft/world/level/block/state/BlockState;F)V
 		ARG 1 blockState
 		ARG 2 probability
-	METHOD test (Lnet/minecraft/world/level/block/state/BlockState;Ljava/util/Random;)Z
-		ARG 1 state
-		ARG 2 random

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/RuleTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/RuleTest.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/world/level/levelgen/structure/templatesystem/RuleTest
+	COMMENT Represents a (possibly randomly influenced) predicate of a given block state to be replaced during world generation.
 	METHOD test (Lnet/minecraft/world/level/block/state/BlockState;Ljava/util/Random;)Z
 		ARG 1 state
 		ARG 2 random

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/StructureManager.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/StructureManager.mapping
@@ -4,26 +4,28 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/StructureManag
 		ARG 2 levelStorage
 		ARG 3 fixerUpper
 	METHOD createAndValidatePathToStructure (Lnet/minecraft/resources/ResourceLocation;Ljava/lang/String;)Ljava/nio/file/Path;
-		ARG 1 structureTemplate
-		ARG 2 ext
+		ARG 1 id
+		ARG 2 extension
 	METHOD createPathToStructure (Lnet/minecraft/resources/ResourceLocation;Ljava/lang/String;)Ljava/nio/file/Path;
-		ARG 1 structureTemplate
-		ARG 2 ext
+		ARG 1 id
+		ARG 2 extension
 	METHOD get (Lnet/minecraft/resources/ResourceLocation;)Ljava/util/Optional;
-		ARG 1 structureTemplate
+		ARG 1 id
 	METHOD getOrCreate (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate;
-		ARG 1 structureTemplate
+		ARG 1 id
+	METHOD lambda$get$0 (Lnet/minecraft/resources/ResourceLocation;)Ljava/util/Optional;
+		ARG 1 key
 	METHOD loadFromGenerated (Lnet/minecraft/resources/ResourceLocation;)Ljava/util/Optional;
-		ARG 1 structureTemplate
+		ARG 1 id
 	METHOD loadFromResource (Lnet/minecraft/resources/ResourceLocation;)Ljava/util/Optional;
-		ARG 1 structureTemplate
+		ARG 1 id
 	METHOD onResourceManagerReload (Lnet/minecraft/server/packs/resources/ResourceManager;)V
 		ARG 1 resourceManager
 	METHOD readStructure (Ljava/io/InputStream;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate;
-		ARG 1 inputStream
+		ARG 1 stream
 	METHOD readStructure (Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate;
 		ARG 1 tag
 	METHOD remove (Lnet/minecraft/resources/ResourceLocation;)V
-		ARG 1 templatePath
+		ARG 1 id
 	METHOD save (Lnet/minecraft/resources/ResourceLocation;)Z
-		ARG 1 structureTemplate
+		ARG 1 id

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings.mapping
@@ -1,13 +1,13 @@
 CLASS net/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings
 	METHOD addProcessor (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureProcessor;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
-		ARG 1 structureProcessor
+		ARG 1 processor
 	METHOD getRandom (Lnet/minecraft/core/BlockPos;)Ljava/util/Random;
-		ARG 1 seed
+		ARG 1 seedPos
 	METHOD getRandomPalette (Ljava/util/List;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate$Palette;
 		ARG 1 palettes
 		ARG 2 pos
 	METHOD popProcessor (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureProcessor;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
-		ARG 1 structureProcessor
+		ARG 1 processor
 	METHOD setBoundingBox (Lnet/minecraft/world/level/levelgen/structure/BoundingBox;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
 		ARG 1 boundingBox
 	METHOD setFinalizeEntities (Z)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
@@ -25,4 +25,4 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/StructurePlace
 	METHOD setRotation (Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
 		ARG 1 rotation
 	METHOD setRotationPivot (Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;
-		ARG 1 center
+		ARG 1 rotationPivot

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/StructureProcessor.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/StructureProcessor.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/world/level/levelgen/structure/templatesystem/StructureProcessor
 	METHOD processBlock (Lnet/minecraft/world/level/LevelReader;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate$StructureBlockInfo;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate$StructureBlockInfo;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;)Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate$StructureBlockInfo;
 		ARG 1 level
+		ARG 3 pos
+		ARG 4 blockInfo
+		ARG 5 relativeBlockInfo
 		ARG 6 settings

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.mapping
@@ -1,16 +1,18 @@
 CLASS net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate
 	METHOD addToLists (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate$StructureBlockInfo;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
 		ARG 0 blockInfo
-		ARG 1 specialBlocks
-		ARG 2 blocksWithTag
-		ARG 3 normalBlocks
+		ARG 1 normalBlocks
+		ARG 2 blocksWithNbt
+		ARG 3 blocksWithSpecialShape
 	METHOD buildInfoList (Ljava/util/List;Ljava/util/List;Ljava/util/List;)Ljava/util/List;
-		ARG 0 specialBlocks
-		ARG 1 blocksWithTag
-		ARG 2 normalBlocks
+		ARG 0 normalBlocks
+		ARG 1 blocksWithNbt
+		ARG 2 blocksWithSpecialShape
 	METHOD calculateConnectedPosition (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/BlockPos;
 		ARG 1 decorator
+		ARG 2 start
 		ARG 3 settings
+		ARG 4 end
 	METHOD calculateRelativePosition (Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/BlockPos;
 		ARG 0 decorator
 		ARG 1 pos
@@ -18,14 +20,13 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/StructureTempl
 		ARG 0 level
 		ARG 1 tag
 	METHOD fillEntityList (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;)V
-		COMMENT takes blocks from the world and puts the data them into this template
 		ARG 1 level
 		ARG 2 startPos
 		ARG 3 endPos
 	METHOD fillFromWorld (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Vec3i;ZLnet/minecraft/world/level/block/Block;)V
 		ARG 1 level
 		ARG 2 pos
-		ARG 3 vec
+		ARG 3 size
 		ARG 4 withEntities
 		ARG 5 toIgnore
 	METHOD filterBlocks (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;Lnet/minecraft/world/level/block/Block;)Ljava/util/List;
@@ -66,8 +67,8 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/StructureTempl
 	METHOD load (Lnet/minecraft/nbt/CompoundTag;)V
 		ARG 1 tag
 	METHOD loadPalette (Lnet/minecraft/nbt/ListTag;Lnet/minecraft/nbt/ListTag;)V
-		ARG 1 palletesNBT
-		ARG 2 blocksNBT
+		ARG 1 paletteTag
+		ARG 2 blocksTag
 	METHOD newDoubleList ([D)Lnet/minecraft/nbt/ListTag;
 		ARG 1 values
 	METHOD newIntegerList ([I)Lnet/minecraft/nbt/ListTag;
@@ -80,13 +81,14 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/StructureTempl
 		ARG 7 withEntities
 	METHOD placeInWorld (Lnet/minecraft/world/level/ServerLevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;Ljava/util/Random;I)Z
 		ARG 1 serverLevel
+		ARG 2 pos
 		ARG 4 settings
 		ARG 5 random
 		ARG 6 flags
 	METHOD processBlockInfos (Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructurePlaceSettings;Ljava/util/List;)Ljava/util/List;
 		ARG 0 level
 		ARG 3 settings
-		ARG 4 blockInfoList
+		ARG 4 blockInfos
 	METHOD save (Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/nbt/CompoundTag;
 		ARG 1 tag
 	METHOD setAuthor (Ljava/lang/String;)V
@@ -103,7 +105,7 @@ CLASS net/minecraft/world/level/levelgen/structure/templatesystem/StructureTempl
 		ARG 3 centerOffset
 	METHOD updateShapeAtEdge (Lnet/minecraft/world/level/LevelAccessor;ILnet/minecraft/world/phys/shapes/DiscreteVoxelShape;III)V
 		ARG 0 level
-		ARG 2 voxelShapePart
+		ARG 2 shape
 		ARG 3 x
 		ARG 4 y
 		ARG 5 z

--- a/data/net/minecraft/world/level/levelgen/structure/templatesystem/TagMatchTest.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/templatesystem/TagMatchTest.mapping
@@ -1,6 +1,3 @@
 CLASS net/minecraft/world/level/levelgen/structure/templatesystem/TagMatchTest
 	METHOD <init> (Lnet/minecraft/tags/Tag;)V
 		ARG 1 tag
-	METHOD test (Lnet/minecraft/world/level/block/state/BlockState;Ljava/util/Random;)Z
-		ARG 1 state
-		ARG 2 random


### PR DESCRIPTION
- Invalid mappings dropped, and verified that any removals are populated again on export.
- Not a lot of mapping done since I don't really understand structures. **but**, the point was to audit and remove any lingering mcp cruft (e.g. `templateManager`), which I have done. And to finish up Phoenix for all of `levelgen`.
- I found bounding boxes were named `box`, `bb`, `sbb`, `boundingBox`, and `bounds`.