### PR TITLE
Phoenix com/mojang/math, and dropping from com/mojang/*

### DIFF
--- a/data/com/mojang/blaze3d/audio/Library.mapping
+++ b/data/com/mojang/blaze3d/audio/Library.mapping
@@ -5,13 +5,9 @@ CLASS com/mojang/blaze3d/audio/Library
 	METHOD releaseChannel (Lcom/mojang/blaze3d/audio/Channel;)V
 		ARG 1 channel
 	CLASS 1
-		METHOD release (Lcom/mojang/blaze3d/audio/Channel;)Z
-			ARG 1 source
 	CLASS ChannelPool
 		METHOD release (Lcom/mojang/blaze3d/audio/Channel;)Z
 			ARG 1 channel
 	CLASS CountingChannelPool
 		METHOD <init> (I)V
 			ARG 1 limit
-		METHOD release (Lcom/mojang/blaze3d/audio/Channel;)Z
-			ARG 1 source

--- a/data/com/mojang/blaze3d/audio/OggAudioStream.mapping
+++ b/data/com/mojang/blaze3d/audio/OggAudioStream.mapping
@@ -8,8 +8,6 @@ CLASS com/mojang/blaze3d/audio/OggAudioStream
 		ARG 1 leftChannel
 		ARG 2 rightChannel
 		ARG 3 output
-	METHOD read (I)Ljava/nio/ByteBuffer;
-		ARG 1 size
 	METHOD readFrame (Lcom/mojang/blaze3d/audio/OggAudioStream$OutputConcat;)Z
 		ARG 1 output
 	CLASS OutputConcat

--- a/data/com/mojang/blaze3d/font/TrueTypeGlyphProvider.mapping
+++ b/data/com/mojang/blaze3d/font/TrueTypeGlyphProvider.mapping
@@ -7,8 +7,6 @@ CLASS com/mojang/blaze3d/font/TrueTypeGlyphProvider
 		ARG 5 shiftX
 		ARG 6 shiftY
 		ARG 7 skip
-	METHOD getGlyph (I)Lcom/mojang/blaze3d/font/TrueTypeGlyphProvider$Glyph;
-		ARG 1 character
 	METHOD lambda$getSupportedGlyphs$0 (I)Z
 		ARG 1 codePoint
 	CLASS Glyph
@@ -20,6 +18,3 @@ CLASS com/mojang/blaze3d/font/TrueTypeGlyphProvider
 			ARG 6 advance
 			ARG 7 bearingX
 			ARG 8 index
-		METHOD upload (II)V
-			ARG 1 xOffset
-			ARG 2 yOffset

--- a/data/com/mojang/blaze3d/vertex/BufferBuilder.mapping
+++ b/data/com/mojang/blaze3d/vertex/BufferBuilder.mapping
@@ -4,11 +4,6 @@ CLASS com/mojang/blaze3d/vertex/BufferBuilder
 	METHOD begin (Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;Lcom/mojang/blaze3d/vertex/VertexFormat;)V
 		ARG 1 mode
 		ARG 2 format
-	METHOD color (IIII)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 red
-		ARG 2 green
-		ARG 3 blue
-		ARG 4 alpha
 	METHOD ensureCapacity (I)V
 		ARG 1 increaseAmount
 	METHOD intConsumer (Lcom/mojang/blaze3d/vertex/VertexFormat$IndexType;)Lit/unimi/dsi/fastutil/ints/IntConsumer;
@@ -22,15 +17,6 @@ CLASS com/mojang/blaze3d/vertex/BufferBuilder
 	METHOD lambda$putSortedQuadIndices$3 ([FII)I
 		ARG 1 index1
 		ARG 2 index2
-	METHOD putByte (IB)V
-		ARG 1 index
-		ARG 2 byteValue
-	METHOD putFloat (IF)V
-		ARG 1 index
-		ARG 2 floatValue
-	METHOD putShort (IS)V
-		ARG 1 index
-		ARG 2 shortValue
 	METHOD putSortedQuadIndices (Lcom/mojang/blaze3d/vertex/VertexFormat$IndexType;)V
 		ARG 1 indexType
 	METHOD restoreSortState (Lcom/mojang/blaze3d/vertex/BufferBuilder$SortState;)V
@@ -43,21 +29,6 @@ CLASS com/mojang/blaze3d/vertex/BufferBuilder
 		ARG 3 sortZ
 	METHOD switchFormat (Lcom/mojang/blaze3d/vertex/VertexFormat;)V
 		ARG 1 format
-	METHOD vertex (FFFFFFFFFIIFFF)V
-		ARG 1 x
-		ARG 2 y
-		ARG 3 z
-		ARG 4 red
-		ARG 5 green
-		ARG 6 blue
-		ARG 7 alpha
-		ARG 8 texU
-		ARG 9 texV
-		ARG 10 overlayUV
-		ARG 11 lightmapUV
-		ARG 12 normalX
-		ARG 13 normalY
-		ARG 14 normalZ
 	CLASS DrawState
 		METHOD <init> (Lcom/mojang/blaze3d/vertex/VertexFormat;IILcom/mojang/blaze3d/vertex/VertexFormat$Mode;Lcom/mojang/blaze3d/vertex/VertexFormat$IndexType;ZZ)V
 			ARG 1 format

--- a/data/com/mojang/blaze3d/vertex/BufferVertexConsumer.mapping
+++ b/data/com/mojang/blaze3d/vertex/BufferVertexConsumer.mapping
@@ -1,18 +1,6 @@
 CLASS com/mojang/blaze3d/vertex/BufferVertexConsumer
-	METHOD color (IIII)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 red
-		ARG 2 green
-		ARG 3 blue
-		ARG 4 alpha
-	METHOD normal (FFF)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 x
-		ARG 2 y
-		ARG 3 z
 	METHOD normalIntValue (F)B
 		ARG 0 num
-	METHOD overlayCoords (II)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 u
-		ARG 2 v
 	METHOD putByte (IB)V
 		ARG 1 index
 		ARG 2 byteValue
@@ -22,17 +10,7 @@ CLASS com/mojang/blaze3d/vertex/BufferVertexConsumer
 	METHOD putShort (IS)V
 		ARG 1 index
 		ARG 2 shortValue
-	METHOD uv (FF)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 u
-		ARG 2 v
-	METHOD uv2 (II)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 u
-		ARG 2 v
 	METHOD uvShort (SSI)Lcom/mojang/blaze3d/vertex/VertexConsumer;
 		ARG 1 u
 		ARG 2 v
 		ARG 3 index
-	METHOD vertex (DDD)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z

--- a/data/com/mojang/blaze3d/vertex/SheetedDecalTextureGenerator.mapping
+++ b/data/com/mojang/blaze3d/vertex/SheetedDecalTextureGenerator.mapping
@@ -3,25 +3,3 @@ CLASS com/mojang/blaze3d/vertex/SheetedDecalTextureGenerator
 		ARG 1 delegate
 		ARG 2 cameraPose
 		ARG 3 normalPose
-	METHOD color (IIII)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 red
-		ARG 2 green
-		ARG 3 blue
-		ARG 4 alpha
-	METHOD normal (FFF)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 x
-		ARG 2 y
-		ARG 3 z
-	METHOD overlayCoords (II)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 u
-		ARG 2 v
-	METHOD uv (FF)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 u
-		ARG 2 v
-	METHOD uv2 (II)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 u
-		ARG 2 v
-	METHOD vertex (DDD)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z

--- a/data/com/mojang/blaze3d/vertex/VertexMultiConsumer.mapping
+++ b/data/com/mojang/blaze3d/vertex/VertexMultiConsumer.mapping
@@ -10,43 +10,6 @@ CLASS com/mojang/blaze3d/vertex/VertexMultiConsumer
 		METHOD <init> (Lcom/mojang/blaze3d/vertex/VertexConsumer;Lcom/mojang/blaze3d/vertex/VertexConsumer;)V
 			ARG 1 first
 			ARG 2 second
-		METHOD color (IIII)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-			ARG 1 red
-			ARG 2 green
-			ARG 3 blue
-			ARG 4 alpha
-		METHOD normal (FFF)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-			ARG 1 x
-			ARG 2 y
-			ARG 3 z
-		METHOD overlayCoords (II)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-			ARG 1 u
-			ARG 2 v
-		METHOD uv (FF)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-			ARG 1 u
-			ARG 2 v
-		METHOD uv2 (II)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-			ARG 1 u
-			ARG 2 v
-		METHOD vertex (DDD)Lcom/mojang/blaze3d/vertex/VertexConsumer;
-			ARG 1 x
-			ARG 3 y
-			ARG 5 z
-		METHOD vertex (FFFFFFFFFIIFFF)V
-			ARG 1 x
-			ARG 2 y
-			ARG 3 z
-			ARG 4 red
-			ARG 5 green
-			ARG 6 blue
-			ARG 7 alpha
-			ARG 8 texU
-			ARG 9 texV
-			ARG 10 overlayUV
-			ARG 11 lightmapUV
-			ARG 12 normalX
-			ARG 13 normalY
-			ARG 14 normalZ
 	CLASS Multiple
 		METHOD <init> ([Lcom/mojang/blaze3d/vertex/VertexConsumer;)V
 			ARG 1 delegates

--- a/data/com/mojang/math/Matrix3f.mapping
+++ b/data/com/mojang/math/Matrix3f.mapping
@@ -1,18 +1,21 @@
 CLASS com/mojang/math/Matrix3f
 	METHOD <init> (Lcom/mojang/math/Matrix3f;)V
-		COMMENT Copy constructor for this class.
 		ARG 1 other
-			COMMENT The instance to copy from
 	METHOD <init> (Lcom/mojang/math/Matrix4f;)V
 		ARG 1 matrix
 	METHOD <init> (Lcom/mojang/math/Quaternion;)V
 		ARG 1 quaternion
 	METHOD add (Lcom/mojang/math/Matrix3f;)V
 		ARG 1 other
+	METHOD bufferIndex (II)I
+		ARG 0 x
+		ARG 1 y
 	METHOD createScaleMatrix (FFF)Lcom/mojang/math/Matrix3f;
 		ARG 0 m00
 		ARG 1 m11
 		ARG 2 m22
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 other
 	METHOD load (Lcom/mojang/math/Matrix3f;)V
 		ARG 1 other
 	METHOD load (Ljava/nio/FloatBuffer;)V
@@ -29,7 +32,14 @@ CLASS com/mojang/math/Matrix3f
 	METHOD mul (Lcom/mojang/math/Quaternion;)V
 		ARG 1 quaternion
 	METHOD set (IIF)V
+		ARG 1 x
+		ARG 2 y
 		ARG 3 value
+	METHOD sortSingularValues (Lcom/mojang/math/Matrix3f;Lcom/mojang/math/Quaternion;)V
+		ARG 0 matrix
+		ARG 1 quaternion
+	METHOD stepJacobi (Lcom/mojang/math/Matrix3f;)Lcom/mojang/math/Quaternion;
+		ARG 0 matrix
 	METHOD store (Ljava/nio/FloatBuffer;)V
 		ARG 1 buffer
 	METHOD store (Ljava/nio/FloatBuffer;Z)V

--- a/data/com/mojang/math/Matrix4f.mapping
+++ b/data/com/mojang/math/Matrix4f.mapping
@@ -5,8 +5,13 @@ CLASS com/mojang/math/Matrix4f
 		ARG 1 quaternion
 	METHOD add (Lcom/mojang/math/Matrix4f;)V
 		ARG 1 other
+	METHOD bufferIndex (II)I
+		ARG 0 x
+		ARG 1 y
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 other
+	METHOD isInteger (F)Z
+		ARG 0 value
 	METHOD load (Lcom/mojang/math/Matrix4f;)V
 		ARG 1 other
 	METHOD load (Ljava/nio/FloatBuffer;)V

--- a/data/com/mojang/math/OctahedralGroup.mapping
+++ b/data/com/mojang/math/OctahedralGroup.mapping
@@ -5,6 +5,8 @@ CLASS com/mojang/math/OctahedralGroup
 		ARG 5 invertX
 		ARG 6 invertY
 		ARG 7 invertZ
+	METHOD compose (Lcom/mojang/math/OctahedralGroup;)Lcom/mojang/math/OctahedralGroup;
+		ARG 1 other
 	METHOD inverts (Lnet/minecraft/core/Direction$Axis;)Z
 		ARG 1 axis
 	METHOD rotate (Lnet/minecraft/core/Direction;)Lnet/minecraft/core/Direction;

--- a/data/com/mojang/math/Quaternion.mapping
+++ b/data/com/mojang/math/Quaternion.mapping
@@ -4,11 +4,16 @@ CLASS com/mojang/math/Quaternion
 		ARG 2 j
 		ARG 3 k
 		ARG 4 r
+	METHOD <init> (FFFZ)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 degrees
 	METHOD <init> (Lcom/mojang/math/Quaternion;)V
 		ARG 1 other
 	METHOD <init> (Lcom/mojang/math/Vector3f;FZ)V
-		ARG 1 vector
-		ARG 2 angle
+		ARG 1 rotationAxis
+		ARG 2 rotationAngle
 		ARG 3 degrees
 	METHOD cos (F)F
 		ARG 0 angle
@@ -19,8 +24,7 @@ CLASS com/mojang/math/Quaternion
 		ARG 1 y
 		ARG 2 z
 	METHOD fromXYZ (Lcom/mojang/math/Vector3f;)Lcom/mojang/math/Quaternion;
-		ARG 0 vector
-			COMMENT A vector, with values in radians
+		ARG 0 radiansVector
 	METHOD fromXYZDegrees (Lcom/mojang/math/Vector3f;)Lcom/mojang/math/Quaternion;
 		ARG 0 degreesVector
 	METHOD fromYXZ (FFF)Lcom/mojang/math/Quaternion;

--- a/data/com/mojang/math/SymmetricGroup3.mapping
+++ b/data/com/mojang/math/SymmetricGroup3.mapping
@@ -1,4 +1,5 @@
 CLASS com/mojang/math/SymmetricGroup3
+	COMMENT The symmetric group S3, also known as all the permutation orders of three elements.
 	METHOD <init> (Ljava/lang/String;IIII)V
 		ARG 3 first
 		ARG 4 second

--- a/data/com/mojang/math/Transformation.mapping
+++ b/data/com/mojang/math/Transformation.mapping
@@ -1,12 +1,22 @@
 CLASS com/mojang/math/Transformation
+	METHOD <init> (Lcom/mojang/math/Matrix4f;)V
+		ARG 1 matrix
+	METHOD <init> (Lcom/mojang/math/Vector3f;Lcom/mojang/math/Quaternion;Lcom/mojang/math/Vector3f;Lcom/mojang/math/Quaternion;)V
+		ARG 1 translation
+		ARG 2 leftRotation
+		ARG 3 scale
+		ARG 4 rightRotation
 	METHOD compose (Lcom/mojang/math/Transformation;)Lcom/mojang/math/Transformation;
 		ARG 1 other
 	METHOD compose (Lcom/mojang/math/Vector3f;Lcom/mojang/math/Quaternion;Lcom/mojang/math/Vector3f;Lcom/mojang/math/Quaternion;)Lcom/mojang/math/Matrix4f;
 		ARG 0 translation
-		ARG 1 rotationLeft
+		ARG 1 leftRotation
 		ARG 2 scale
-		ARG 3 rotationRight
+		ARG 3 rightRotation
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 other
+	METHOD slerp (Lcom/mojang/math/Transformation;F)Lcom/mojang/math/Transformation;
+		ARG 1 transformation
+		ARG 2 delta
 	METHOD toAffine (Lcom/mojang/math/Matrix4f;)Lcom/mojang/datafixers/util/Pair;
 		ARG 0 matrix

--- a/data/com/mojang/math/Vector3d.mapping
+++ b/data/com/mojang/math/Vector3d.mapping
@@ -1,10 +1,5 @@
 CLASS com/mojang/math/Vector3d
-	FIELD x D
-		COMMENT The X coordinate
-	FIELD y D
-		COMMENT The Y coordinate
-	FIELD z D
-		COMMENT The Z coordinate
+	COMMENT A mutable, three dimensional vector with double floating point precision.
 	METHOD <init> (DDD)V
 		ARG 1 x
 		ARG 3 y

--- a/data/com/mojang/math/Vector3f.mapping
+++ b/data/com/mojang/math/Vector3f.mapping
@@ -1,12 +1,13 @@
 CLASS com/mojang/math/Vector3f
+	COMMENT A mutable, three dimensional vector with single floating point precision.
 	METHOD <init> (FFF)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
 	METHOD <init> (Lcom/mojang/math/Vector4f;)V
-		ARG 1 vector4f
+		ARG 1 vector
 	METHOD <init> (Lnet/minecraft/world/phys/Vec3;)V
-		ARG 1 vec3
+		ARG 1 vector
 	METHOD add (FFF)V
 		ARG 1 x
 		ARG 2 y

--- a/data/com/mojang/math/Vector4f.mapping
+++ b/data/com/mojang/math/Vector4f.mapping
@@ -1,11 +1,12 @@
 CLASS com/mojang/math/Vector4f
+	COMMENT A mutable, four dimensional vector with single floating point precision.
 	METHOD <init> (FFFF)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
 		ARG 4 w
 	METHOD <init> (Lcom/mojang/math/Vector3f;)V
-		ARG 1 vector3f
+		ARG 1 vector
 	METHOD add (FFFF)V
 		ARG 1 x
 		ARG 2 y

--- a/data/com/mojang/realmsclient/KeyCombo.mapping
+++ b/data/com/mojang/realmsclient/KeyCombo.mapping
@@ -1,3 +1,8 @@
 CLASS com/mojang/realmsclient/KeyCombo
+	METHOD <init> ([C)V
+		ARG 1 chars
+	METHOD <init> ([CLjava/lang/Runnable;)V
+		ARG 1 chars
+		ARG 2 onCompletion
 	METHOD keyPressed (C)Z
 		ARG 1 key

--- a/data/com/mojang/realmsclient/RealmsMainScreen.mapping
+++ b/data/com/mojang/realmsclient/RealmsMainScreen.mapping
@@ -1,9 +1,6 @@
 CLASS com/mojang/realmsclient/RealmsMainScreen
 	METHOD <init> (Lnet/minecraft/client/gui/screens/Screen;)V
 		ARG 1 lastScreen
-	METHOD charTyped (CI)Z
-		ARG 1 codePoint
-		ARG 2 modifiers
 	METHOD configureClicked (Lcom/mojang/realmsclient/dto/RealmsServer;)V
 		ARG 1 realmsServer
 	METHOD drawRealmsLogo (Lcom/mojang/blaze3d/vertex/PoseStack;II)V
@@ -12,23 +9,10 @@ CLASS com/mojang/realmsclient/RealmsMainScreen
 		ARG 3 y
 	METHOD findServer (J)Lcom/mojang/realmsclient/dto/RealmsServer;
 		ARG 1 serverId
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
 	METHOD leaveClicked (Lcom/mojang/realmsclient/dto/RealmsServer;)V
 		ARG 1 realmsServer
-	METHOD mouseClicked (DDI)Z
-		ARG 1 mouseX
-		ARG 3 mouseY
-		ARG 5 button
 	METHOD removeServer (Lcom/mojang/realmsclient/dto/RealmsServer;)V
 		ARG 1 realmsServer
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	METHOD setCreatedTrial (Z)V
 		ARG 1 createdTrial
 	METHOD shouldConfigureButtonBeVisible (Lcom/mojang/realmsclient/dto/RealmsServer;)Z
@@ -42,69 +26,9 @@ CLASS com/mojang/realmsclient/RealmsMainScreen
 	METHOD updateButtonStates (Lcom/mojang/realmsclient/dto/RealmsServer;)V
 		ARG 1 realmsServer
 	CLASS NewsButton
-		METHOD renderButton (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-			ARG 1 matrixStack
-			ARG 2 mouseX
-			ARG 3 mouseY
-			ARG 4 partialTicks
 	CLASS TrialEntry
-		METHOD mouseClicked (DDI)Z
-			ARG 1 mouseX
-			ARG 3 mouseY
-			ARG 5 button
-		METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIIIZF)V
-			ARG 1 matrixStack
-			ARG 2 index
-			ARG 3 top
-			ARG 4 left
-			ARG 5 width
-			ARG 6 height
-			ARG 7 mouseX
-			ARG 8 mouseY
-			ARG 9 isMouseOver
-			ARG 10 partialTicks
 	CLASS CloseButton
-		METHOD renderButton (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-			ARG 1 matrixStack
-			ARG 2 mouseX
-			ARG 3 mouseY
-			ARG 4 partialTicks
 	CLASS ServerEntry
-		METHOD mouseClicked (DDI)Z
-			ARG 1 mouseX
-			ARG 3 mouseY
-			ARG 5 button
-		METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIIIZF)V
-			ARG 1 matrixStack
-			ARG 2 index
-			ARG 3 top
-			ARG 4 left
-			ARG 5 width
-			ARG 6 height
-			ARG 7 mouseX
-			ARG 8 mouseY
-			ARG 9 isMouseOver
-			ARG 10 partialTicks
 	CLASS ShowPopupButton
-		METHOD renderButton (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-			ARG 1 matrixStack
-			ARG 2 mouseX
-			ARG 3 mouseY
-			ARG 4 partialTicks
 	CLASS RealmSelectionList
-		METHOD keyPressed (III)Z
-			ARG 1 keyCode
-			ARG 2 scanCode
-			ARG 3 modifiers
-		METHOD mouseClicked (DDI)Z
-			ARG 1 mouseX
-			ARG 3 mouseY
-			ARG 5 button
-		METHOD setSelected (Lcom/mojang/realmsclient/RealmsMainScreen$Entry;)V
-			ARG 1 entry
 	CLASS PendingInvitesButton
-		METHOD renderButton (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-			ARG 1 matrixStack
-			ARG 2 mouseX
-			ARG 3 mouseY
-			ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/Unit.mapping
+++ b/data/com/mojang/realmsclient/Unit.mapping
@@ -1,0 +1,11 @@
+CLASS com/mojang/realmsclient/Unit
+	METHOD convertTo (JLcom/mojang/realmsclient/Unit;)D
+		ARG 0 bytes
+		ARG 2 unit
+	METHOD getLargest (J)Lcom/mojang/realmsclient/Unit;
+		ARG 0 bytes
+	METHOD humanReadable (J)Ljava/lang/String;
+		ARG 0 bytes
+	METHOD humanReadable (JLcom/mojang/realmsclient/Unit;)Ljava/lang/String;
+		ARG 0 bytes
+		ARG 2 unit

--- a/data/com/mojang/realmsclient/gui/RealmsWorldSlotButton.mapping
+++ b/data/com/mojang/realmsclient/gui/RealmsWorldSlotButton.mapping
@@ -1,6 +1,1 @@
 CLASS com/mojang/realmsclient/gui/RealmsWorldSlotButton
-	METHOD renderButton (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen.mapping
@@ -2,15 +2,6 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen
 	METHOD <init> (Lnet/minecraft/client/gui/screens/Screen;Lcom/mojang/realmsclient/dto/Backup;)V
 		ARG 1 lastScreen
 		ARG 2 backup
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	CLASS BackupInfoList
 		METHOD <init> (Lcom/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen;Lnet/minecraft/client/Minecraft;)V
 			ARG 2 minecraft
@@ -18,14 +9,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen
 		METHOD <init> (Lcom/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen;Ljava/lang/String;Ljava/lang/String;)V
 			ARG 2 key
 			ARG 3 value
-		METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIIIZF)V
-			ARG 1 matrixStack
-			ARG 2 index
-			ARG 3 top
-			ARG 4 left
-			ARG 5 width
-			ARG 6 height
-			ARG 7 mouseX
-			ARG 8 mouseY
-			ARG 9 isMouseOver
-			ARG 10 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsBackupScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsBackupScreen.mapping
@@ -3,15 +3,6 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsBackupScreen
 		ARG 1 lastScreen
 		ARG 2 serverData
 		ARG 3 slotId
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	METHOD renderMousehoverTooltip (Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/network/chat/Component;II)V
 		ARG 1 poseStack
 	CLASS Entry
@@ -21,30 +12,11 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsBackupScreen
 			ARG 1 poseStack
 		METHOD getMediumDatePresentation (Ljava/util/Date;)Ljava/lang/String;
 			ARG 1 date
-		METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIIIZF)V
-			ARG 1 matrixStack
-			ARG 2 index
-			ARG 3 top
-			ARG 4 left
-			ARG 5 width
-			ARG 6 height
-			ARG 7 mouseX
-			ARG 8 mouseY
-			ARG 9 isMouseOver
-			ARG 10 partialTicks
 		METHOD renderBackupItem (Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/realmsclient/dto/Backup;IIII)V
 			ARG 1 poseStack
 			ARG 2 backup
 	CLASS BackupObjectSelectionList
 		METHOD addEntry (Lcom/mojang/realmsclient/dto/Backup;)V
 			ARG 1 backup
-		METHOD mouseClicked (DDI)Z
-			ARG 1 mouseX
-			ARG 3 mouseY
-			ARG 5 button
-		METHOD renderBackground (Lcom/mojang/blaze3d/vertex/PoseStack;)V
-			ARG 1 matrixStack
 		METHOD selectInviteListItem (I)V
 			ARG 1 index
-		METHOD setSelected (Lcom/mojang/realmsclient/gui/screens/RealmsBackupScreen$Entry;)V
-			ARG 1 entry

--- a/data/com/mojang/realmsclient/gui/screens/RealmsBrokenWorldScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsBrokenWorldScreen.mapping
@@ -11,12 +11,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsBrokenWorldScreen
 		ARG 8 slotIndex
 	METHOD fetchServerData (J)V
 		ARG 1 serverId
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsClientOutdatedScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsClientOutdatedScreen.mapping
@@ -2,12 +2,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsClientOutdatedScreen
 	METHOD <init> (Lnet/minecraft/client/gui/screens/Screen;Z)V
 		ARG 1 lastScreen
 		ARG 2 outdated
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsConfigureWorldScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsConfigureWorldScreen.mapping
@@ -20,18 +20,9 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsConfigureWorldScreen
 		ARG 1 button
 	METHOD joinRealm (Lcom/mojang/realmsclient/dto/RealmsServer;)V
 		ARG 1 server
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
 	METHOD openTheWorld (ZLnet/minecraft/client/gui/screens/Screen;)V
 		ARG 1 join
 		ARG 2 lastScreen
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	METHOD renderMousehoverTooltip (Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/network/chat/Component;II)V
 		ARG 1 poseStack
 	METHOD saveSlotSettings (Lcom/mojang/realmsclient/dto/RealmsWorldOptions;)V

--- a/data/com/mojang/realmsclient/gui/screens/RealmsConfirmScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsConfirmScreen.mapping
@@ -3,8 +3,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsConfirmScreen
 		ARG 1 callback
 		ARG 2 title1
 		ARG 3 title2
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsCreateRealmScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsCreateRealmScreen.mapping
@@ -2,15 +2,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsCreateRealmScreen
 	METHOD <init> (Lcom/mojang/realmsclient/dto/RealmsServer;Lcom/mojang/realmsclient/RealmsMainScreen;)V
 		ARG 1 server
 		ARG 2 lastScreen
-	METHOD charTyped (CI)Z
-		ARG 1 codePoint
-		ARG 2 modifiers
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsDownloadLatestWorldScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsDownloadLatestWorldScreen.mapping
@@ -13,12 +13,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsDownloadLatestWorldScreen
 		ARG 2 bytesPersSecond
 	METHOD drawProgressBar (Lcom/mojang/blaze3d/vertex/PoseStack;)V
 		ARG 1 poseStack
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen.mapping
@@ -16,8 +16,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen
 	METHOD errorMessage (Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/Component;)V
 		ARG 1 line1
 		ARG 2 line2
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsInviteScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsInviteScreen.mapping
@@ -3,14 +3,5 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsInviteScreen
 		ARG 1 configureScreen
 		ARG 2 lastScreen
 		ARG 3 serverData
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	METHOD showError (Lnet/minecraft/network/chat/Component;)V
 		ARG 1 errorMsg

--- a/data/com/mojang/realmsclient/gui/screens/RealmsLongConfirmationScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsLongConfirmationScreen.mapping
@@ -5,15 +5,6 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsLongConfirmationScreen
 		ARG 3 line2
 		ARG 4 line3
 		ARG 5 yesNoQuestion
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	CLASS Type
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;I)V
 			ARG 3 text

--- a/data/com/mojang/realmsclient/gui/screens/RealmsLongRunningMcoTaskScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsLongRunningMcoTaskScreen.mapping
@@ -2,14 +2,5 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsLongRunningMcoTaskScreen
 	METHOD <init> (Lnet/minecraft/client/gui/screens/Screen;Lcom/mojang/realmsclient/util/task/LongRunningTask;)V
 		ARG 1 lastScreen
 		ARG 2 task
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	METHOD setTitle (Lnet/minecraft/network/chat/Component;)V
 		ARG 1 title

--- a/data/com/mojang/realmsclient/gui/screens/RealmsNotificationsScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsNotificationsScreen.mapping
@@ -1,6 +1,1 @@
 CLASS com/mojang/realmsclient/gui/screens/RealmsNotificationsScreen
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsParentalConsentScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsParentalConsentScreen.mapping
@@ -1,8 +1,3 @@
 CLASS com/mojang/realmsclient/gui/screens/RealmsParentalConsentScreen
 	METHOD <init> (Lnet/minecraft/client/gui/screens/Screen;)V
 		ARG 1 nextScreen
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen.mapping
@@ -1,38 +1,10 @@
 CLASS com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen
 	METHOD <init> (Lnet/minecraft/client/gui/screens/Screen;)V
 		ARG 1 lastScreen
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	METHOD renderMousehoverTooltip (Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/network/chat/Component;II)V
 		ARG 1 poseStack
 		ARG 2 toolTip
 		ARG 3 mouseX
 		ARG 4 mouseY
 	CLASS Entry
-		METHOD mouseClicked (DDI)Z
-			ARG 1 mouseX
-			ARG 3 mouseY
-			ARG 5 button
-		METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIIIZF)V
-			ARG 1 matrixStack
-			ARG 2 index
-			ARG 3 top
-			ARG 4 left
-			ARG 5 width
-			ARG 6 height
-			ARG 7 mouseX
-			ARG 8 mouseY
-			ARG 9 isMouseOver
-			ARG 10 partialTicks
 	CLASS PendingInvitationSelectionList
-		METHOD renderBackground (Lcom/mojang/blaze3d/vertex/PoseStack;)V
-			ARG 1 matrixStack
-		METHOD setSelected (Lcom/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$Entry;)V
-			ARG 1 entry

--- a/data/com/mojang/realmsclient/gui/screens/RealmsPlayerScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsPlayerScreen.mapping
@@ -8,31 +8,11 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsPlayerScreen
 		ARG 1 poseStack
 	METHOD drawRemoveIcon (Lcom/mojang/blaze3d/vertex/PoseStack;IIII)V
 		ARG 1 poseStack
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	METHOD renderMousehoverTooltip (Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/network/chat/Component;II)V
 		ARG 1 poseStack
 	CLASS Entry
 		METHOD <init> (Lcom/mojang/realmsclient/gui/screens/RealmsPlayerScreen;Lcom/mojang/realmsclient/dto/PlayerInfo;)V
 			ARG 2 playerInfo
-		METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIIIZF)V
-			ARG 1 matrixStack
-			ARG 2 index
-			ARG 3 top
-			ARG 4 left
-			ARG 5 width
-			ARG 6 height
-			ARG 7 mouseX
-			ARG 8 mouseY
-			ARG 9 isMouseOver
-			ARG 10 partialTicks
 		METHOD renderInvitedItem (Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/realmsclient/dto/PlayerInfo;IIII)V
 			ARG 1 poseStack
 			ARG 2 playerInfo
@@ -43,11 +23,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsPlayerScreen
 	CLASS InvitedObjectSelectionList
 		METHOD addEntry (Lcom/mojang/realmsclient/dto/PlayerInfo;)V
 			ARG 1 playerInfo
-		METHOD mouseClicked (DDI)Z
-			ARG 1 mouseX
-			ARG 3 mouseY
-			ARG 5 button
-		METHOD renderBackground (Lcom/mojang/blaze3d/vertex/PoseStack;)V
-			ARG 1 matrixStack
-		METHOD setSelected (Lcom/mojang/realmsclient/gui/screens/RealmsPlayerScreen$Entry;)V
-			ARG 1 entry

--- a/data/com/mojang/realmsclient/gui/screens/RealmsResetNormalWorldScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsResetNormalWorldScreen.mapping
@@ -2,8 +2,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsResetNormalWorldScreen
 	METHOD <init> (Ljava/util/function/Consumer;Lnet/minecraft/network/chat/Component;)V
 		ARG 1 callback
 		ARG 2 buttonTitle
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen.mapping
@@ -19,22 +19,8 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen
 		ARG 6 buttonTitle
 		ARG 7 resetWorldRunnable
 		ARG 8 callback
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	METHOD setResetTitle (Lnet/minecraft/network/chat/Component;)V
 		ARG 1 resetTitle
 	METHOD setSlot (I)V
 		ARG 1 slot
 	CLASS FrameButton
-		METHOD renderButton (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-			ARG 1 matrixStack
-			ARG 2 mouseX
-			ARG 3 mouseY
-			ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen.mapping
@@ -4,33 +4,5 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen
 		ARG 3 slotId
 		ARG 4 lastScreen
 		ARG 5 callback
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	CLASS Entry
-		METHOD mouseClicked (DDI)Z
-			ARG 1 mouseX
-			ARG 3 mouseY
-			ARG 5 button
-		METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIIIZF)V
-			ARG 1 matrixStack
-			ARG 2 index
-			ARG 3 top
-			ARG 4 left
-			ARG 5 width
-			ARG 6 height
-			ARG 7 mouseX
-			ARG 8 mouseY
-			ARG 9 isMouseOver
-			ARG 10 partialTicks
 	CLASS WorldSelectionList
-		METHOD renderBackground (Lcom/mojang/blaze3d/vertex/PoseStack;)V
-			ARG 1 matrixStack
-		METHOD setSelected (Lcom/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen$Entry;)V
-			ARG 1 entry

--- a/data/com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen.mapping
@@ -8,37 +8,9 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen
 		ARG 2 callback
 		ARG 3 worldType
 		ARG 4 worldTemplatePaginatedList
-	METHOD mouseClicked (DDI)Z
-		ARG 1 mouseX
-		ARG 3 mouseY
-		ARG 5 button
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	METHOD setWarning ([Lnet/minecraft/network/chat/Component;)V
 		ARG 1 warning
 	CLASS Entry
 		METHOD <init> (Lcom/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen;Lcom/mojang/realmsclient/dto/WorldTemplate;)V
 			ARG 2 template
-		METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIIIZF)V
-			ARG 1 matrixStack
-			ARG 2 index
-			ARG 3 top
-			ARG 4 left
-			ARG 5 width
-			ARG 6 height
-			ARG 7 mouseX
-			ARG 8 mouseY
-			ARG 9 isMouseOver
-			ARG 10 partialTicks
 	CLASS WorldTemplateObjectSelectionList
-		METHOD mouseClicked (DDI)Z
-			ARG 1 mouseX
-			ARG 3 mouseY
-			ARG 5 button
-		METHOD renderBackground (Lcom/mojang/blaze3d/vertex/PoseStack;)V
-			ARG 1 matrixStack
-		METHOD setSelected (Lcom/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$Entry;)V
-			ARG 1 entry

--- a/data/com/mojang/realmsclient/gui/screens/RealmsSettingsScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsSettingsScreen.mapping
@@ -2,12 +2,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsSettingsScreen
 	METHOD <init> (Lcom/mojang/realmsclient/gui/screens/RealmsConfigureWorldScreen;Lcom/mojang/realmsclient/dto/RealmsServer;)V
 		ARG 1 configureWorldScreen
 		ARG 2 serverData
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen.mapping
@@ -4,15 +4,6 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen
 		ARG 2 options
 		ARG 3 worldType
 		ARG 4 activeSlot
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	CLASS SettingsSlider
 		METHOD <init> (Lcom/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen;IIIIFF)V
 			ARG 2 x
@@ -21,9 +12,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen
 			ARG 5 value
 			ARG 6 minValue
 			ARG 7 maxValue
-		METHOD onClick (DD)V
-			ARG 1 mouseX
-			ARG 3 mouseY
-		METHOD onRelease (DD)V
-			ARG 1 mouseX
-			ARG 3 mouseY

--- a/data/com/mojang/realmsclient/gui/screens/RealmsSubscriptionInfoScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsSubscriptionInfoScreen.mapping
@@ -5,12 +5,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsSubscriptionInfoScreen
 		ARG 3 mainScreen
 	METHOD getSubscription (J)V
 		ARG 1 serverId
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsTermsScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsTermsScreen.mapping
@@ -7,16 +7,3 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsTermsScreen
 		ARG 1 lastScreen
 		ARG 2 mainScreen
 		ARG 3 realmsServer
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD mouseClicked (DDI)Z
-		ARG 1 mouseX
-		ARG 3 mouseY
-		ARG 5 button
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks

--- a/data/com/mojang/realmsclient/gui/screens/RealmsUploadScreen.mapping
+++ b/data/com/mojang/realmsclient/gui/screens/RealmsUploadScreen.mapping
@@ -17,15 +17,6 @@ CLASS com/mojang/realmsclient/gui/screens/RealmsUploadScreen
 	METHOD drawUploadSpeed0 (Lcom/mojang/blaze3d/vertex/PoseStack;J)V
 		ARG 1 poseStack
 		ARG 2 bytesPersSecond
-	METHOD keyPressed (III)Z
-		ARG 1 keyCode
-		ARG 2 scanCode
-		ARG 3 modifiers
-	METHOD render (Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V
-		ARG 1 matrixStack
-		ARG 2 mouseX
-		ARG 3 mouseY
-		ARG 4 partialTicks
 	METHOD setErrorMessage ([Lnet/minecraft/network/chat/Component;)V
 		ARG 1 errorMessage
 	METHOD tarGzipArchive (Ljava/io/File;)Ljava/io/File;


### PR DESCRIPTION
For the actual review-required changes, see the [second commit](https://github.com/ParchmentMC/Parchment/commit/94358f67165e89a2f64b347b33a2b2a2d3a15deb), as the first was running drop invalid mappings across all of `com/mojang`. Why? Because

- Simon had already went through `com/mojang/blaze3d` in the Phoenix spreadsheet, but trimming out unnecessary fat is still good.
- I went through `com/mojang/math` just now.
- The rest of `com/mojang` is realms which I don't want to touch with a ten foot pole but I'll happily trim out fat if I can easily verify it shouldn't exist.

Here is the diff from `generateOfficialExport` from the first commit:

```diff
227c227
<               "name": "source"
---
>               "name": "channel"
267c267
<               "name": "source"
---
>               "name": "channel"
12637c12637
<               "name": "matrixStack"
---
>               "name": "poseStack"
13956c13956
<               "name": "matrixStack"
---
>               "name": "poseStack"
14209c14209
<               "name": "matrixStack"
---
>               "name": "poseStack"
14599c14599
<               "name": "matrixStack"
---
>               "name": "poseStack"
14798c14798
<               "name": "matrixStack"
---
>               "name": "poseStack"
```