### PR TITLE
Documented n.m.resources and n.m.core.RegistryAccess 

### DIFF
--- a/data/net/minecraft/core/AxisCycle.mapping
+++ b/data/net/minecraft/core/AxisCycle.mapping
@@ -15,26 +15,5 @@ CLASS net/minecraft/core/AxisCycle
 	METHOD cycle (Lnet/minecraft/core/Direction$Axis;)Lnet/minecraft/core/Direction$Axis;
 		ARG 1 axis
 	CLASS 1
-		METHOD cycle (IIILnet/minecraft/core/Direction$Axis;)I
-			ARG 1 x
-			ARG 2 y
-			ARG 3 z
-			ARG 4 axis
-		METHOD cycle (Lnet/minecraft/core/Direction$Axis;)Lnet/minecraft/core/Direction$Axis;
-			ARG 1 axis
 	CLASS 2
-		METHOD cycle (IIILnet/minecraft/core/Direction$Axis;)I
-			ARG 1 x
-			ARG 2 y
-			ARG 3 z
-			ARG 4 axis
-		METHOD cycle (Lnet/minecraft/core/Direction$Axis;)Lnet/minecraft/core/Direction$Axis;
-			ARG 1 axis
 	CLASS 3
-		METHOD cycle (IIILnet/minecraft/core/Direction$Axis;)I
-			ARG 1 x
-			ARG 2 y
-			ARG 3 z
-			ARG 4 axis
-		METHOD cycle (Lnet/minecraft/core/Direction$Axis;)Lnet/minecraft/core/Direction$Axis;
-			ARG 1 axis

--- a/data/net/minecraft/core/AxisCycle.mapping
+++ b/data/net/minecraft/core/AxisCycle.mapping
@@ -14,6 +14,3 @@ CLASS net/minecraft/core/AxisCycle
 		ARG 4 axis
 	METHOD cycle (Lnet/minecraft/core/Direction$Axis;)Lnet/minecraft/core/Direction$Axis;
 		ARG 1 axis
-	CLASS 1
-	CLASS 2
-	CLASS 3

--- a/data/net/minecraft/core/BlockPos.mapping
+++ b/data/net/minecraft/core/BlockPos.mapping
@@ -11,22 +11,12 @@ CLASS net/minecraft/core/BlockPos
 		ARG 1 vector
 	METHOD <init> (Lnet/minecraft/world/phys/Vec3;)V
 		ARG 1 vector
-	METHOD above ()Lnet/minecraft/core/BlockPos;
-		COMMENT Offset this BlockPos 1 block up
-	METHOD above (I)Lnet/minecraft/core/BlockPos;
-		COMMENT Offset this BlockPos n blocks up
-		ARG 1 n
 	METHOD asLong (III)J
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
 	METHOD atY (I)Lnet/minecraft/core/BlockPos;
 		ARG 1 y
-	METHOD below ()Lnet/minecraft/core/BlockPos;
-		COMMENT Offset this BlockPos 1 block down
-	METHOD below (I)Lnet/minecraft/core/BlockPos;
-		COMMENT Offset this BlockPos n blocks down
-		ARG 1 n
 	METHOD betweenClosed (IIIIII)Ljava/lang/Iterable;
 		COMMENT Creates an Iterable that returns all positions in the box specified by the given corners. <strong>Coordinates must be in order</strong>" e.g. x1 <= x2.
 		COMMENT
@@ -99,10 +89,6 @@ CLASS net/minecraft/core/BlockPos
 	METHOD randomInCube (Ljava/util/Random;ILnet/minecraft/core/BlockPos;I)Ljava/lang/Iterable;
 		ARG 0 random
 		ARG 1 amount
-	METHOD relative (Lnet/minecraft/core/Direction;I)Lnet/minecraft/core/BlockPos;
-		COMMENT Offsets this BlockPos n blocks in the given direction
-		ARG 1 facing
-		ARG 2 n
 	METHOD rotate (Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/core/BlockPos;
 		ARG 1 rotation
 	METHOD south (I)Lnet/minecraft/core/BlockPos;
@@ -134,11 +120,6 @@ CLASS net/minecraft/core/BlockPos
 		METHOD move (Lnet/minecraft/core/Direction;I)Lnet/minecraft/core/BlockPos$MutableBlockPos;
 			ARG 1 direction
 			ARG 2 n
-		METHOD relative (Lnet/minecraft/core/Direction;I)Lnet/minecraft/core/BlockPos;
-			ARG 1 facing
-			ARG 2 n
-		METHOD rotate (Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/core/BlockPos;
-			ARG 1 rotation
 		METHOD set (DDD)Lnet/minecraft/core/BlockPos$MutableBlockPos;
 			ARG 1 x
 			ARG 3 y

--- a/data/net/minecraft/core/DefaultedRegistry.mapping
+++ b/data/net/minecraft/core/DefaultedRegistry.mapping
@@ -7,18 +7,3 @@ CLASS net/minecraft/core/DefaultedRegistry
 		ARG 1 defaultName
 		ARG 2 registryKey
 		ARG 3 lifecycle
-	METHOD byId (I)Ljava/lang/Object;
-		ARG 1 value
-	METHOD get (Lnet/minecraft/resources/ResourceLocation;)Ljava/lang/Object;
-		ARG 1 name
-	METHOD getId (Ljava/lang/Object;)I
-		ARG 1 value
-	METHOD getKey (Ljava/lang/Object;)Lnet/minecraft/resources/ResourceLocation;
-		ARG 1 value
-	METHOD getOptional (Lnet/minecraft/resources/ResourceLocation;)Ljava/util/Optional;
-		ARG 1 id
-	METHOD registerMapping (ILnet/minecraft/resources/ResourceKey;Ljava/lang/Object;Lcom/mojang/serialization/Lifecycle;)Ljava/lang/Object;
-		ARG 1 id
-		ARG 2 name
-		ARG 3 instance
-		ARG 4 lifecycle

--- a/data/net/minecraft/core/IdMapper.mapping
+++ b/data/net/minecraft/core/IdMapper.mapping
@@ -6,9 +6,5 @@ CLASS net/minecraft/core/IdMapper
 	METHOD addMapping (Ljava/lang/Object;I)V
 		ARG 1 key
 		ARG 2 value
-	METHOD byId (I)Ljava/lang/Object;
-		ARG 1 value
 	METHOD contains (I)Z
 		ARG 1 id
-	METHOD getId (Ljava/lang/Object;)I
-		ARG 1 value

--- a/data/net/minecraft/core/MappedRegistry.mapping
+++ b/data/net/minecraft/core/MappedRegistry.mapping
@@ -1,8 +1,4 @@
 CLASS net/minecraft/core/MappedRegistry
-	METHOD byId (I)Ljava/lang/Object;
-		ARG 1 value
-	METHOD containsKey (Lnet/minecraft/resources/ResourceLocation;)Z
-		ARG 1 name
 	METHOD dataPackCodec (Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Lifecycle;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
 		ARG 0 registryKey
 		ARG 1 lifecycle
@@ -11,42 +7,16 @@ CLASS net/minecraft/core/MappedRegistry
 		ARG 0 registryKey
 		ARG 1 lifecycle
 		ARG 2 mapCodec
-	METHOD get (Lnet/minecraft/resources/ResourceKey;)Ljava/lang/Object;
-		ARG 1 key
-	METHOD get (Lnet/minecraft/resources/ResourceLocation;)Ljava/lang/Object;
-		ARG 1 name
-	METHOD getId (Ljava/lang/Object;)I
-		ARG 1 value
-	METHOD getKey (Ljava/lang/Object;)Lnet/minecraft/resources/ResourceLocation;
-		ARG 1 value
-	METHOD getResourceKey (Ljava/lang/Object;)Ljava/util/Optional;
-		ARG 1 value
-	METHOD lifecycle (Ljava/lang/Object;)Lcom/mojang/serialization/Lifecycle;
-		ARG 1 object
 	METHOD networkCodec (Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Lifecycle;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
 		ARG 0 registryKey
 		ARG 1 lifecycle
 		ARG 2 codec
-	METHOD register (Lnet/minecraft/resources/ResourceKey;Ljava/lang/Object;Lcom/mojang/serialization/Lifecycle;)Ljava/lang/Object;
-		ARG 1 name
-		ARG 2 instance
-		ARG 3 lifecycle
-	METHOD registerMapping (ILnet/minecraft/resources/ResourceKey;Ljava/lang/Object;Lcom/mojang/serialization/Lifecycle;)Ljava/lang/Object;
-		ARG 1 id
-		ARG 2 name
-		ARG 3 instance
-		ARG 4 lifecycle
 	METHOD registerMapping (ILnet/minecraft/resources/ResourceKey;Ljava/lang/Object;Lcom/mojang/serialization/Lifecycle;Z)Ljava/lang/Object;
 		ARG 1 id
 		ARG 2 key
 		ARG 3 value
 		ARG 4 lifecycle
 		ARG 5 logDuplicateKeys
-	METHOD registerOrOverride (Ljava/util/OptionalInt;Lnet/minecraft/resources/ResourceKey;Ljava/lang/Object;Lcom/mojang/serialization/Lifecycle;)Ljava/lang/Object;
-		ARG 1 index
-		ARG 2 registryKey
-		ARG 3 value
-		ARG 4 lifecycle
 	METHOD withNameAndId (Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/MapCodec;)Lcom/mojang/serialization/MapCodec;
 		ARG 0 registryKey
 		ARG 1 mapCodec

--- a/data/net/minecraft/core/Registry.mapping
+++ b/data/net/minecraft/core/Registry.mapping
@@ -14,8 +14,6 @@ CLASS net/minecraft/core/Registry
 		ARG 1 key
 	METHOD get (Lnet/minecraft/resources/ResourceLocation;)Ljava/lang/Object;
 		ARG 1 name
-	METHOD getId (Ljava/lang/Object;)I
-		ARG 1 value
 	METHOD getKey (Ljava/lang/Object;)Lnet/minecraft/resources/ResourceLocation;
 		COMMENT @return the name used to identify the given object within this registry or {@code null} if the object is not within this registry
 		ARG 1 value

--- a/data/net/minecraft/core/RegistryAccess.mapping
+++ b/data/net/minecraft/core/RegistryAccess.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/core/RegistryAccess
 	COMMENT The root level registry, essentially a registry of registries. It is also an access point, hence the name, for other dynamic registries.
 	FIELD BUILTIN Lnet/minecraft/core/RegistryAccess$RegistryHolder;
 		COMMENT A registry access containing the builtin registries (excluding the dimension type registry).
-		COMMENT When this class is loaded, this registry holder is initialized, which involves copying all elements from the builtin registries at {@link net.minecraft.data.BuiltinRegistries} into this field, which contains the static, code defined registries such as configured features, etc.}.
+		COMMENT When this class is loaded, this registry holder is initialized, which involves copying all elements from the builtin registries at {@link net.minecraft.data.BuiltinRegistries} into this field, which contains the static, code defined registries such as configured features, etc.
 		COMMENT Early classloading of this class <strong>can cause issues</strong> because this field will not contain any elements registered to the builtin registries after classloading of {@code RegistryAccess}.
 	FIELD REGISTRIES Ljava/util/Map;
 		COMMENT Metadata about all registries. Maps registry keys to a {@link RegistryData} object, which defines the codecs, and if applicable, codecs for synchronization of the registry's elements.
@@ -70,8 +70,7 @@ CLASS net/minecraft/core/RegistryAccess
 		COMMENT The returned registry can not gaurentee that it is writable here, so the return type is widened to {@code Registry<E>} instead.
 		ARG 1 registryKey
 	METHOD registryOrThrow (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/core/Registry;
-		COMMENT Accesses a given registry by key where the registry is assumed to exist.
-		COMMENT @throws IllegalStateException if the provided registry does not exist.
+		COMMENT A variant of {@link #registry(ResourceKey)} that throws if the registry does not exist.
 		ARG 1 registryKey
 	CLASS RegistryData
 		COMMENT A small record representing metadata about a given registry.
@@ -91,7 +90,7 @@ CLASS net/minecraft/core/RegistryAccess
 		METHOD sendToClient ()Z
 			COMMENT @return {@code true} if this registry should be synchronized with the client.
 	CLASS RegistryHolder
-		COMMENT Creates a new registry holder which includes all default dynamic registries.
+		COMMENT The default implementation of {@link RegistryAccess}, which stores it's registries in a backing map of registry keys to registries.
 		FIELD NETWORK_CODEC Lcom/mojang/serialization/Codec;
 			COMMENT This is the codec used to serialize the entire contents of the builtin registries to send to client. It is built using the metadata information of {@link #REGISTRIES} in order to filter what registries to sync.
 			COMMENT Internally, the codec is built as a wrapper around a {@code Map<ResourceKey<?>, Registry<?>>}.

--- a/data/net/minecraft/core/RegistryAccess.mapping
+++ b/data/net/minecraft/core/RegistryAccess.mapping
@@ -1,32 +1,120 @@
 CLASS net/minecraft/core/RegistryAccess
+	COMMENT The root level registry, essentially a registry of registries. It is also an access point, hence the name, for other dynamic registries.
+	FIELD BUILTIN Lnet/minecraft/core/RegistryAccess$RegistryHolder;
+		COMMENT A registry access containing the builtin registries (excluding the dimension type registry).
+		COMMENT When this class is loaded, this registry holder is initialized, which involves copying all elements from the builtin registries at {@link net.minecraft.data.BuiltinRegistries} into this field, which contains the static, code defined registries such as configured features, etc.}.
+		COMMENT Early classloading of this class <strong>can cause issues</strong> because this field will not contain any elements registered to the builtin registries after classloading of {@code RegistryAccess}.
+	FIELD REGISTRIES Ljava/util/Map;
+		COMMENT Metadata about all registries. Maps registry keys to a {@link RegistryData} object, which defines the codecs, and if applicable, codecs for synchronization of the registry's elements.
 	METHOD addBuiltinElements (Lnet/minecraft/core/RegistryAccess$RegistryHolder;Lnet/minecraft/resources/RegistryReadOps$ResourceAccess$MemoryMap;Lnet/minecraft/core/RegistryAccess$RegistryData;)V
-		ARG 0 registryHolder
+		COMMENT Adds builtin elements from the builtin registries to the {@code destinationRegistryHolder} with several quirks.
+		COMMENT The source for all builtin elements is the {@link #BUILTIN} field, which contains builtin elements of all registries excluding the dimension type registry, as they were at time this class was initialized.
+		COMMENT Then, depending on the registry, one of two things will occur:
+		COMMENT <ul>
+		COMMENT <li>If the registry is the noise generator settings, or dimension type registry, elements will be copied (id, object, name, and lifecycle) directly into the registry of {@code destinationRegistryHolder}</li>
+		COMMENT <li>However, in all other cases, the registry element is <strong>encoded into JSON</strong> and entered into the {@code destinationRegistryAccess}. The registry holder is not modified in these cases.</li>
+		COMMENT </ul>
+		ARG 0 destinationRegistryHolder
+		ARG 1 resourceAccess
+		ARG 2 data
+	METHOD builtin ()Lnet/minecraft/core/RegistryAccess$RegistryHolder;
+		COMMENT Creates a {@link RegistryHolder} containing the builtin vanilla registries.
+		COMMENT The way it does so is a little convoluted.
+		COMMENT <ol>
+		COMMENT <li>It copies the contents of the noise generator settings and dimension types, directly from the {@link #BUILTIN} field. (Note that since {@link #BUILTIN} does not contain entries for dimension types the latter copy is rather pointless)</li>
+		COMMENT <li>All other registry elements are serialized to JSON, and stored (including their registry int ID and lifecycles), in the {@code MemoryMap}.</li>
+		COMMENT <li>A {@link net.minecraft.resources.RegistryReadOps} is created, and stores the {@code MemoryMap} as the ops' {code ResourceAccess}. The ops is then read from, which internally lists resources from the {@code ResourceAccess}, and deserializes all elements from JSON.</li>
+		COMMENT </ol>
+		COMMENT Despite seeming like the worlds worst deep copy, this actually has an explicit purpose: Registry elements are totally unknown to the registry - they do not expose a copy method, they can be of an arbitrary type, and more importantly, <strong>they may reference other registry elements</strong>.
+		COMMENT This is a key reason why registries need to be copied in this serialize, deserialize loop, as opposed to simply copying the elements. References between registry elements need to be maintained, as the registry elements need to still point to valid elements in the overall registries.
 	METHOD copy (Lnet/minecraft/core/RegistryAccess$RegistryHolder;Lnet/minecraft/core/Registry;)V
-		ARG 0 registryHolder
-		ARG 1 registry
+		COMMENT Copy the values of the {@code sourceRegistry} into the {@code destinationRegistryHolder}
+		ARG 0 destinationRegistryHolder
+		ARG 1 sourceRegistry
 	METHOD copyBuiltin (Lnet/minecraft/core/RegistryAccess$RegistryHolder;Lnet/minecraft/resources/ResourceKey;)V
-		ARG 0 registryHolder
-		ARG 1 key
+		COMMENT Copy the values of the builtin registry {@code registryKey} into the {@code destinationRegistryHolder} registry holder.
+		ARG 0 destinationRegistryHolder
+		ARG 1 registryKey
+	METHOD lambda$readRegistry$6 (Lcom/mojang/serialization/DataResult$PartialResult;)V
+		ARG 0 error
+	METHOD lambda$static$3 (Lnet/minecraft/resources/ResourceKey;)Z
+		ARG 0 registryKey
+	METHOD lambda$static$4 (Lnet/minecraft/core/RegistryAccess$RegistryHolder;Lnet/minecraft/resources/ResourceKey;)V
+		ARG 1 registryKey
+	METHOD load (Lnet/minecraft/core/RegistryAccess;Lnet/minecraft/resources/RegistryReadOps;)V
+		COMMENT Loads all registries from the {@code ops} into the {@code destinationRegistryAccess}.
+		ARG 0 destinationRegistryAccess
+		ARG 1 ops
 	METHOD ownedRegistry (Lnet/minecraft/resources/ResourceKey;)Ljava/util/Optional;
+		COMMENT Get the registry owned by this registry access. The returned value, if it exists, will be writable.
+		ARG 1 registryKey
+	METHOD ownedRegistryOrThrow (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/core/WritableRegistry;
+		COMMENT A variant of {@link #ownedRegistry(ResourceKey)} that throws if the registry does not exist.
 		ARG 1 registryKey
 	METHOD put (Lcom/google/common/collect/ImmutableMap$Builder;Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;)V
+		ARG 0 builder
 		ARG 1 registryKey
-		ARG 2 codec
+		ARG 2 elementCodec
 	METHOD put (Lcom/google/common/collect/ImmutableMap$Builder;Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/Codec;)V
+		ARG 0 builder
 		ARG 1 registryKey
-		ARG 2 codec
-		ARG 3 codec2
+		ARG 2 elementCodec
+		ARG 3 networkCodec
+	METHOD readRegistry (Lnet/minecraft/resources/RegistryReadOps;Lnet/minecraft/core/RegistryAccess;Lnet/minecraft/core/RegistryAccess$RegistryData;)V
+		COMMENT Load, or reads, a single registry from the containing {@code ops}, into the {@code destinationRegistryAccess}.
+		ARG 0 ops
+		ARG 1 destinationRegistryAccess
+		ARG 2 data
+	METHOD registry (Lnet/minecraft/resources/ResourceKey;)Ljava/util/Optional;
+		COMMENT Get the registry owned by this registry access by the given key. If it doesn't exist, the default registry of registries is queried instead, which contains static registries such as blocks.
+		COMMENT The returned registry can not gaurentee that it is writable here, so the return type is widened to {@code Registry<E>} instead.
+		ARG 1 registryKey
+	METHOD registryOrThrow (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/core/Registry;
+		COMMENT Accesses a given registry by key where the registry is assumed to exist.
+		COMMENT @throws IllegalStateException if the provided registry does not exist.
+		ARG 1 registryKey
 	CLASS RegistryData
+		COMMENT A small record representing metadata about a given registry.
 		METHOD <init> (Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/Codec;)V
 			ARG 1 key
+				COMMENT The registry key of this registry.
 			ARG 2 codec
+				COMMENT The codec used to serialize this registry's elements internally.
 			ARG 3 networkCodec
+				COMMENT The codec used to serialize this registry's elements when sending them to the client. This being null implies that the contents of this registry are not synchronized to client.
+		METHOD codec ()Lcom/mojang/serialization/Codec;
+			COMMENT @return The codec used to serialize this registry's elements internally.
+		METHOD key ()Lnet/minecraft/resources/ResourceKey;
+			COMMENT @return The registry key of the registry this metadata is describing.
+		METHOD networkCodec ()Lcom/mojang/serialization/Codec;
+			COMMENT @return The codec used to serialize this registry's elements when sending them to the client. Returns {@code null} if this registry should not be synchronized with the client.
+		METHOD sendToClient ()Z
+			COMMENT @return {@code true} if this registry should be synchronized with the client.
 	CLASS RegistryHolder
+		COMMENT Creates a new registry holder which includes all default dynamic registries.
+		FIELD NETWORK_CODEC Lcom/mojang/serialization/Codec;
+			COMMENT This is the codec used to serialize the entire contents of the builtin registries to send to client. It is built using the metadata information of {@link #REGISTRIES} in order to filter what registries to sync.
+			COMMENT Internally, the codec is built as a wrapper around a {@code Map<ResourceKey<?>, Registry<?>>}.
+			COMMENT Each registry that defines a network codec is wrapped with {@link net.minecraft.core.MappedRegistry.networkCodec} to create a codec which preserves id, name and element values.
+		METHOD <init> (Ljava/util/Map;)V
+			ARG 1 registries
 		METHOD captureMap (Lcom/mojang/serialization/codecs/UnboundedMapCodec;)Lcom/mojang/serialization/Codec;
 			ARG 0 unboundedMapCodec
 		METHOD createRegistry (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/core/MappedRegistry;
 			ARG 0 registryKey
 		METHOD getNetworkCodec (Lnet/minecraft/resources/ResourceKey;)Lcom/mojang/serialization/DataResult;
+			ARG 0 registryKey
+		METHOD lambda$captureMap$3 (Ljava/util/Map$Entry;)Z
+			ARG 0 entry
+		METHOD lambda$captureMap$4 (Lnet/minecraft/core/RegistryAccess$RegistryHolder;)Ljava/util/Map;
+			ARG 0 registryHolder
+		METHOD lambda$getNetworkCodec$5 (Lnet/minecraft/core/RegistryAccess$RegistryData;)Lcom/mojang/serialization/Codec;
+			ARG 0 data
+		METHOD lambda$makeNetworkCodec$0 (Lnet/minecraft/core/MappedRegistry;)Lcom/mojang/serialization/DataResult;
+			ARG 0 registry
+		METHOD lambda$makeNetworkCodec$1 (Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+			ARG 1 networkCodec
+		METHOD lambda$makeNetworkCodec$2 (Lnet/minecraft/resources/ResourceKey;)Lcom/mojang/serialization/DataResult;
 			ARG 0 registryKey
 		METHOD lambda$ownedRegistry$7 (Lnet/minecraft/core/MappedRegistry;)Lnet/minecraft/core/WritableRegistry;
 			ARG 0 registry

--- a/data/net/minecraft/resources/DelegatingOps.mapping
+++ b/data/net/minecraft/resources/DelegatingOps.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/resources/DelegatingOps
+	COMMENT A {@link DynamicOps} that delegates all functionality to an internal delegate. Comments and parameters here are copied from {@link DynamicOps} in DataFixerUpper.
 	METHOD <init> (Lcom/mojang/serialization/DynamicOps;)V
 		ARG 1 delegate
 	METHOD convertTo (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Ljava/lang/Object;

--- a/data/net/minecraft/resources/RegistryFileCodec.mapping
+++ b/data/net/minecraft/resources/RegistryFileCodec.mapping
@@ -1,11 +1,15 @@
 CLASS net/minecraft/resources/RegistryFileCodec
+	COMMENT A codec that wraps a single element, or "file", within a registry. Possibly allows inline definitions, and always falls back to the element codec (and thus writing the registry element inline) if it fails to decode from the registry.
 	METHOD <init> (Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;Z)V
 		ARG 1 registryKey
 		ARG 2 elementCodec
 		ARG 3 allowInline
 	METHOD create (Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;)Lnet/minecraft/resources/RegistryFileCodec;
+		COMMENT Creates a codec for a single registry element, which is held as an un-resolved {@code Supplier<E>}. Both inline definitions of the object, and references to an existing registry element id are allowed.
 		ARG 0 registryKey
+			COMMENT The registry which elements may belong to.
 		ARG 1 elementCodec
+			COMMENT The codec used to decode either inline definitions, or elements before entering them into the registry.
 	METHOD create (Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;Z)Lnet/minecraft/resources/RegistryFileCodec;
 		ARG 0 registryKey
 		ARG 1 elementCodec
@@ -18,9 +22,16 @@ CLASS net/minecraft/resources/RegistryFileCodec
 		ARG 2 ops
 		ARG 3 prefix
 	METHOD homogeneousList (Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
-		COMMENT @return a codec for a list of suppliers of a registry object
+		COMMENT Creates a codec of registry elements, represented as un-resolved {@code Supplier<E>}s. This list can consist of either:
+		COMMENT <ol>
+		COMMENT <li>A list of registry element ids, which are resolved by the registry ops and element codec into registered elements.</li>
+		COMMENT <li>A list of inline definitions of registry elements, which are not registered.</li>
+		COMMENT </ol>
+		COMMENT Due to a deficiency of {@link com.mojang.serialization.codecs.EitherCodec}, when the first fails to resolve a single element, this will instead fallback to trying to interpret the list as a list of inline definitions. And will <strong>not report the earlier error</strong>, instead reporting that the list consists of elements that are "Not a JSON object".
 		ARG 0 registryKey
+			COMMENT The registry which elements may belong to.
 		ARG 1 elementCodec
+			COMMENT The codec used to decode either inline definitions, or elements before entering them into the registry.
 	METHOD lambda$decode$6 (Ljava/lang/Object;)Ljava/util/function/Supplier;
 		ARG 0 element
 	METHOD lambda$decode$7 (Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;

--- a/data/net/minecraft/resources/RegistryLookupCodec.mapping
+++ b/data/net/minecraft/resources/RegistryLookupCodec.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/resources/RegistryLookupCodec
+	COMMENT A codec that provides a registry, by key to the consumer, assuming the ops used is a {@code net.minecraft.resources.RegistryReadOps}.
+	COMMENT No data is encoded or decoded, rather, the registry is looked up in the ops's {@code registryAccess}.
+	COMMENT This provides a read-only view of a registry, and can reference registries owned by the registry access or not.
 	METHOD <init> (Lnet/minecraft/resources/ResourceKey;)V
 		ARG 1 registryKey
 	METHOD create (Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/resources/RegistryLookupCodec;
@@ -6,6 +9,8 @@ CLASS net/minecraft/resources/RegistryLookupCodec
 	METHOD decode (Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;)Lcom/mojang/serialization/DataResult;
 		ARG 1 ops
 		ARG 2 input
+	METHOD encode (Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
+		ARG 1 registry
 	METHOD encode (Lnet/minecraft/core/Registry;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
 		ARG 1 input
 		ARG 2 ops

--- a/data/net/minecraft/resources/RegistryLookupCodec.mapping
+++ b/data/net/minecraft/resources/RegistryLookupCodec.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/resources/RegistryLookupCodec
 	METHOD decode (Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;)Lcom/mojang/serialization/DataResult;
 		ARG 1 ops
 		ARG 2 input
-	METHOD encode (Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
+	METHOD encode (Lnet/minecraft/core/Registry;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
 		ARG 1 registry
 	METHOD encode (Lnet/minecraft/core/Registry;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
 		ARG 1 input

--- a/data/net/minecraft/resources/RegistryReadOps.mapping
+++ b/data/net/minecraft/resources/RegistryReadOps.mapping
@@ -1,9 +1,15 @@
 CLASS net/minecraft/resources/RegistryReadOps
+	COMMENT A combination of a {@link DelegatingOps}, to do raw data reading, a {@link net.minecraft.core.RegistryAccess}, to populate, and a {@link RegistryReadOps.ResourceAccess} which represents a organized set of encoded registry data, to decode from.
+	COMMENT In that sense, this ops wraps an entire encoded view of a registry, and it's companion decoding functionality, rather than being a general purpose ops.
 	METHOD <init> (Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resources/RegistryReadOps$ResourceAccess;Lnet/minecraft/core/RegistryAccess;Ljava/util/IdentityHashMap;)V
 		ARG 1 delegate
+			COMMENT The delegate dynamic ops to use for raw data decoding.
 		ARG 2 resources
+			COMMENT The resource access. A view of an encoded set of registry data that this ops can read from.
 		ARG 3 registryAccess
+			COMMENT The destination registry access to load registry elements into, during decoding.
 		ARG 4 readCache
+			COMMENT A map from registry and element key pairs, to cached (optional) decoding results. This is used to optimize reference to registry elements that may have already been decoded.
 	METHOD create (Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resources/RegistryReadOps$ResourceAccess;Lnet/minecraft/core/RegistryAccess;)Lnet/minecraft/resources/RegistryReadOps;
 		ARG 0 delegate
 		ARG 1 resources
@@ -13,6 +19,8 @@ CLASS net/minecraft/resources/RegistryReadOps
 		ARG 1 resourceManager
 		ARG 2 registryAccess
 	METHOD createAndLoad (Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resources/RegistryReadOps$ResourceAccess;Lnet/minecraft/core/RegistryAccess;)Lnet/minecraft/resources/RegistryReadOps;
+		COMMENT Creates a new {@link RegistryReadOps} with the provided resources as input. Then, loads the entirety of the resources into the provided {@code registryAccess}.
+		COMMENT The {@link RegistryReadOps} is returned but can be discarded after, as all resources will have been loaded into the {@code registryAccess}.
 		ARG 0 delegate
 		ARG 1 resources
 		ARG 2 registryAccess
@@ -21,14 +29,29 @@ CLASS net/minecraft/resources/RegistryReadOps
 		ARG 1 resourceManager
 		ARG 2 registryAccess
 	METHOD decodeElement (Ljava/lang/Object;Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;Z)Lcom/mojang/serialization/DataResult;
+		COMMENT Decodes a single element from the registry {@code registryKey}.
+		COMMENT The {@code registryAccess} must own the registry, as it will be modified.
+		COMMENT If inline definitions are allowed, the element may be encoded as raw data, which will be read using the {@code elementCodec} and returned without mutating the internal {@code registryAccess}.
+		COMMENT In all other cases, this will read the registry element's id as a {@link net.minecraft.resources.ResourceLocation}. A supplier to the registry element will be returned, which accesses the underlying registry, or an error, if the registry element was unable to be decoded here or in previous calls.
 		ARG 1 input
+			COMMENT The input encoded registry element, either a id or an inline definition.
 		ARG 2 registryKey
+			COMMENT The registry the element might belong to.
 		ARG 3 elementCodec
+			COMMENT The codec to decode individual elements from the registry, if inline definitions are supported, or, to decode the element from the resource access.
 		ARG 4 allowInline
+			COMMENT If inline definitions that are not present in any registry are allowed here.
 	METHOD decodeElements (Lnet/minecraft/core/MappedRegistry;Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/DataResult;
+		COMMENT Decodes all elements of a given registry as per the semantics of {@link #decodeElement(Object, ResourceKey, Codec, boolean)}.
+		COMMENT Lists resources internally from the resource access, and requires that they be be json files prefixed with the registry name.
+		COMMENT If so, individual elements are read and registered into the registry, accumulating errors in the returned result.
+		COMMENT The partial result will contain all successfully decoded and registered elements.
 		ARG 1 registry
+			COMMENT The (empty) registry to decode elements into.
 		ARG 2 registryKey
+			COMMENT The key of the registry.
 		ARG 3 elementCodec
+			COMMENT A codec used to decode individual registry elements from the resource access.
 	METHOD lambda$decodeElement$1 (Ljava/lang/Object;)Ljava/util/function/Supplier;
 		ARG 0 element
 	METHOD lambda$decodeElement$2 (Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;
@@ -54,6 +77,8 @@ CLASS net/minecraft/resources/RegistryReadOps
 		ARG 1 registryKey
 	METHOD registry (Lnet/minecraft/resources/ResourceKey;)Lcom/mojang/serialization/DataResult;
 		ARG 1 registryKey
+	CLASS ReadCache
+		COMMENT This is a cheap java version of a type alias. Because {@code ReadCache<E>} is shorter than {@code Map<ResourceKey<E>, DataResult<Supplier<E>>}.
 	CLASS ResourceAccess
 		METHOD forResourceManager (Lnet/minecraft/server/packs/resources/ResourceManager;)Lnet/minecraft/resources/RegistryReadOps$ResourceAccess;
 			ARG 0 manager
@@ -72,6 +97,9 @@ CLASS net/minecraft/resources/RegistryReadOps
 			METHOD listResources (Lnet/minecraft/resources/ResourceKey;)Ljava/util/Collection;
 				ARG 1 registryKey
 		CLASS MemoryMap
+			COMMENT An in-memory, JSON serialized form of a {@link net.minecraft.coreRegistryAccess}.
+			COMMENT It retains integer ID and lifecycles of every registry element, and is used to bridge the gap between {@link RegistryReadOps} and {@link net.minecraft.resources.RegistryWriteOps} when using the pair in conjunction to perform a deep copy of the entire registries.
+			COMMENT This implements {@link ResourceAccess} as it is used as the access for a {@link RegistryReadOps} to read from, when the builtin registries are being initialized.
 			METHOD add (Lnet/minecraft/core/RegistryAccess$RegistryHolder;Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Encoder;ILjava/lang/Object;Lcom/mojang/serialization/Lifecycle;)V
 				ARG 1 registryAccess
 				ARG 2 resourceKey

--- a/data/net/minecraft/resources/RegistryReadOps.mapping
+++ b/data/net/minecraft/resources/RegistryReadOps.mapping
@@ -95,8 +95,8 @@ CLASS net/minecraft/resources/RegistryReadOps
 			METHOD lambda$parseElement$1 (Ljava/lang/Object;)Lcom/mojang/datafixers/util/Pair;
 				ARG 0 element
 		CLASS MemoryMap
-			COMMENT An in-memory, JSON serialized form of a {@link net.minecraft.coreRegistryAccess}.
-			COMMENT It retains integer ID and lifecycles of every registry element, and is used to bridge the gap between {@link RegistryReadOps} and {@link net.minecraft.resources.RegistryWriteOps} when using the pair in conjunction to perform a deep copy of the entire registries.
+			COMMENT An in-memory, JSON serialized form of a {@link net.minecraft.core.RegistryAccess}.
+			COMMENT It retains the integer IDs and lifecycles of every registry element, and is used to bridge the gap between {@link RegistryReadOps} and {@link net.minecraft.resources.RegistryWriteOps} when using the pair in conjunction to perform a deep copy of the entire registries.
 			COMMENT This implements {@link ResourceAccess} as it is used as the access for a {@link RegistryReadOps} to read from, when the builtin registries are being initialized.
 			METHOD add (Lnet/minecraft/core/RegistryAccess$RegistryHolder;Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Encoder;ILjava/lang/Object;Lcom/mojang/serialization/Lifecycle;)V
 				ARG 1 registryAccess

--- a/data/net/minecraft/resources/RegistryReadOps.mapping
+++ b/data/net/minecraft/resources/RegistryReadOps.mapping
@@ -94,8 +94,6 @@ CLASS net/minecraft/resources/RegistryReadOps
 				ARG 0 fileName
 			METHOD lambda$parseElement$1 (Ljava/lang/Object;)Lcom/mojang/datafixers/util/Pair;
 				ARG 0 element
-			METHOD listResources (Lnet/minecraft/resources/ResourceKey;)Ljava/util/Collection;
-				ARG 1 registryKey
 		CLASS MemoryMap
 			COMMENT An in-memory, JSON serialized form of a {@link net.minecraft.coreRegistryAccess}.
 			COMMENT It retains integer ID and lifecycles of every registry element, and is used to bridge the gap between {@link RegistryReadOps} and {@link net.minecraft.resources.RegistryWriteOps} when using the pair in conjunction to perform a deep copy of the entire registries.
@@ -113,5 +111,3 @@ CLASS net/minecraft/resources/RegistryReadOps
 				ARG 1 resourceKey
 			METHOD lambda$parseElement$2 (Lnet/minecraft/resources/ResourceKey;Ljava/lang/Object;)Lcom/mojang/datafixers/util/Pair;
 				ARG 2 element
-			METHOD listResources (Lnet/minecraft/resources/ResourceKey;)Ljava/util/Collection;
-				ARG 1 registryKey

--- a/data/net/minecraft/resources/RegistryWriteOps.mapping
+++ b/data/net/minecraft/resources/RegistryWriteOps.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/resources/RegistryWriteOps
+	COMMENT A {@link DelegatingOps} which uses a backing {@link RegistryAccess} to write elements.
 	METHOD <init> (Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/core/RegistryAccess;)V
 		ARG 1 delegate
 		ARG 2 registryAccess
@@ -6,7 +7,13 @@ CLASS net/minecraft/resources/RegistryWriteOps
 		ARG 0 delegate
 		ARG 1 registryAccess
 	METHOD encode (Ljava/lang/Object;Ljava/lang/Object;Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/DataResult;
+		COMMENT Encodes an element of a given registry.
+		COMMENT Since the registry key needs to be provided in order to know what registry to encode the element into, this cannot override the {@code encode} method in {@link DelegatingOps}.
+		COMMENT Instead, callers that use this ops (such as {@link net.minecraft.resources.RegistryFileCodec}) are forced to {@code instanceof} check if the ops is a {@code RegistryWriteOps} and call the specialized {@code encode} method instead.
 		ARG 1 element
+			COMMENT The object to encode, optionally, an element in a registry
 		ARG 2 prefix
 		ARG 3 registryKey
+			COMMENT The registry in which the element may be found.
 		ARG 4 elementCodec
+			COMMENT A direct codec to serialize an element. If the registry key does not exist in the held {@link #registryAccess}, or the element does not exist in the registry, this will be used as the fallback encoder.

--- a/data/net/minecraft/resources/ResourceKey.mapping
+++ b/data/net/minecraft/resources/ResourceKey.mapping
@@ -1,12 +1,8 @@
 CLASS net/minecraft/resources/ResourceKey
-	COMMENT An immutable key for a resource, in terms of the name of its parent registry and its location
-	COMMENT in that registry.
-	COMMENT
-	COMMENT <p>{@link net.minecraft.core.Registry} uses this to return resource keys for registry
-	COMMENT objects via {@link net.minecraft.core.Registry#getResourceKey(Object)}. It also uses
-	COMMENT this class to store its name, with the parent registry name set to {@code minecraft:root}.
-	COMMENT When used in this way it is usually referred to as a "registry key".</p>
-	COMMENT
+	COMMENT An immutable key for a resource, in terms of the name of its parent registry and its location in that registry.
+	COMMENT <p>
+	COMMENT {@link net.minecraft.core.Registry} uses this to return resource keys for registry objects via {@link net.minecraft.core.Registry#getResourceKey(Object)}. It also uses this class to store its name, with the parent registry name set to {@code minecraft:root}. When used in this way it is usually referred to as a "registry key".</p>
+	COMMENT <p>
 	COMMENT @param <T> The type of the resource represented by this {@code ResourceKey}, or the type of the registry if it is a registry key.
 	COMMENT @see net.minecraft.resources.ResourceLocation
 	FIELD location Lnet/minecraft/resources/ResourceLocation;
@@ -17,27 +13,22 @@ CLASS net/minecraft/resources/ResourceKey
 		ARG 1 registryName
 		ARG 2 location
 	METHOD create (Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/resources/ResourceKey;
-		COMMENT Constructs a new {@code ResourceKey} for a resource with the specified
-		COMMENT {@code location} within the registry specified by the given {@code registryKey}.
+		COMMENT Constructs a new {@code ResourceKey} for a resource with the specified {@code location} within the registry specified by the given {@code registryKey}.
 		COMMENT
-		COMMENT @return the created resource key. The registry name is set to the location of the
-		COMMENT specified {@code registryKey} and with the specified {@code location} as the
-		COMMENT location of the resource.
+		COMMENT @return the created resource key. The registry name is set to the location of the specified {@code registryKey} and with the specified {@code location} as the location of the resource.
 		ARG 0 registryKey
 		ARG 1 location
 	METHOD create (Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/resources/ResourceKey;
 		ARG 0 registryName
 		ARG 1 location
 	METHOD createRegistryKey (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/resources/ResourceKey;
-		COMMENT @return the created registry key. The registry name is set to
-		COMMENT {@code minecraft:root} and the location the specified {@code registryName}.
+		COMMENT @return the created registry key. The registry name is set to {@code minecraft:root} and the location the specified {@code registryName}.
 		ARG 0 location
 	METHOD elementKey (Lnet/minecraft/resources/ResourceKey;)Ljava/util/function/Function;
-		COMMENT @return a function that maps a {@link net.minecraft.resources.ResourceLocation} to an
-		COMMENT equivalent child {@code ResourceKey} of the specified {@code registryKey}.
+		COMMENT @return a function that maps a {@link net.minecraft.resources.ResourceLocation} to an equivalent child {@code ResourceKey} of the specified {@code registryKey}.
 		ARG 0 registryKey
 	METHOD isFor (Lnet/minecraft/resources/ResourceKey;)Z
-		COMMENT @return {@code true} if this resource key is a direct child of the specified {@code registryKey}
+		COMMENT @return {@code true} if this resource key is a direct child of the specified {@code registryKey}.
 		ARG 1 registryKey
 	METHOD lambda$create$0 (Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/resources/ResourceLocation;Ljava/lang/String;)Lnet/minecraft/resources/ResourceKey;
 		ARG 2 key

--- a/data/net/minecraft/resources/ResourceLocation.mapping
+++ b/data/net/minecraft/resources/ResourceLocation.mapping
@@ -1,17 +1,11 @@
 CLASS net/minecraft/resources/ResourceLocation
 	COMMENT An immutable location of a resource, in terms of a path and namespace.
-	COMMENT
-	COMMENT <p>This is used as an identifier for a resource, usually for those housed in a
-	COMMENT {@link net.minecraft.core.Registry}, such as blocks and items.</p>
-	COMMENT
-	COMMENT <p>{@code minecraft} is always taken as the default namespace for a resource location when
-	COMMENT none is explicitly stated. When using this for registering objects, this namespace
-	COMMENT <b>should</b> only be used for resources added by Minecraft itself.</p>
-	COMMENT
-	COMMENT <p>Generally, and by the implementation of {@link #toString()}, the string representation of
-	COMMENT this class is expressed in the form {@code namespace:path}. The colon is also used as the
-	COMMENT default separator for parsing strings as a {@code ResourceLocation}.</p>
-	COMMENT
+	COMMENT <p>
+	COMMENT This is used as an identifier for a resource, usually for those housed in a {@link net.minecraft.core.Registry}, such as blocks and items.
+	COMMENT <p>
+	COMMENT {@code minecraft} is always taken as the default namespace for a resource location when none is explicitly stated. When using this for registering objects, this namespace <strong>should</strong> only be used for resources added by Minecraft itself.
+	COMMENT <p>
+	COMMENT Generally, and by the implementation of {@link #toString()}, the string representation of this class is expressed in the form {@code namespace:path}. The colon is also used as the default separator for parsing strings as a {@code ResourceLocation}.
 	COMMENT @see net.minecraft.resources.ResourceKey
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 location
@@ -37,23 +31,17 @@ CLASS net/minecraft/resources/ResourceLocation
 		ARG 0 path
 	METHOD isValidResourceLocation (Ljava/lang/String;)Z
 		COMMENT Splits the specified {@code location} into a namespace and path by a colon, checking both are valid.
-		COMMENT
-		COMMENT <p>If no colon is present in the {@code location}, the namespace defaults to {@code minecraft}, taking
-		COMMENT the {@code location} as the path.</p>
-		COMMENT
+		COMMENT <p>
+		COMMENT If no colon is present in the {@code location}, the namespace defaults to {@code minecraft}, taking the {@code location} as the path.</p>
 		COMMENT @return {@code true} if both the decomposed namespace and path are valid
 		COMMENT @see #isValidPath(String)
 		COMMENT @see #isValidNamespace(String)
 		ARG 0 location
 	METHOD of (Ljava/lang/String;C)Lnet/minecraft/resources/ResourceLocation;
-		COMMENT Constructs a {@code ResourceLocation} from the specified {@code location}, split into a namespace and
-		COMMENT path by the specified {@code separator} char.
-		COMMENT
-		COMMENT <p>If the {@code separator} char is not present in the {@code location}, the namespace defaults to
-		COMMENT {@code minecraft}, taking the {@code location} as the path.</p>
-		COMMENT
-		COMMENT @throws net.minecraft.ResourceLocationException if there is a non {@code [a-z0-9_.-]} character in the
-		COMMENT decomposed namespace or a non {@code [a-z0-9/._-]} character in the decomposed path.
+		COMMENT Constructs a {@code ResourceLocation} from the specified {@code location}, split into a namespace and path by the specified {@code separator} char.
+		COMMENT <p>
+		COMMENT If the {@code separator} char is not present in the {@code location}, the namespace defaults to {@code minecraft}, taking the {@code location} as the path.
+		COMMENT @throws net.minecraft.ResourceLocationException if there is a non {@code [a-z0-9_.-]} character in the decomposed namespace or a non {@code [a-z0-9/._-]} character in the decomposed path.
 		COMMENT @see #tryParse(String)
 		COMMENT @see #isValidResourceLocation(String)
 		ARG 0 location
@@ -67,12 +55,9 @@ CLASS net/minecraft/resources/ResourceLocation
 	METHOD tryParse (Ljava/lang/String;)Lnet/minecraft/resources/ResourceLocation;
 		COMMENT Attempts to parse the specified {@code location} as a {@code ResourceLocation} by splitting it into a
 		COMMENT namespace and path by a colon.
-		COMMENT
-		COMMENT <p>If no colon is present in the {@code location}, the namespace defaults to {@code minecraft}, taking
-		COMMENT the {@code location} as the path.</p>
-		COMMENT
-		COMMENT @return the parsed resource location; otherwise {@code null} if there is a non {@code [a-z0-9_.-]}
-		COMMENT character in the decomposed namespace or a non {@code [a-z0-9/._-]} character in the decomposed path
+		COMMENT <p>
+		COMMENT If no colon is present in the {@code location}, the namespace defaults to {@code minecraft}, taking the {@code location} as the path.
+		COMMENT @return the parsed resource location; otherwise {@code null} if there is a non {@code [a-z0-9_.-]} character in the decomposed namespace or a non {@code [a-z0-9/._-]} character in the decomposed path
 		COMMENT @see #of(String, char)
 		ARG 0 location
 			COMMENT the location string to try to parse as a {@code ResourceLocation}
@@ -83,9 +68,9 @@ CLASS net/minecraft/resources/ResourceLocation
 	CLASS Serializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/resources/ResourceLocation;
 			ARG 1 json
-			ARG 2 type
+			ARG 2 typeOfT
 			ARG 3 context
 		METHOD serialize (Lnet/minecraft/resources/ResourceLocation;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 			ARG 1 resourceLocation
-			ARG 2 type
+			ARG 2 typeOfT
 			ARG 3 context


### PR DESCRIPTION
Also included: cleanup in `net.minecraft.resources` and `net.minecraft.core`, dropping some unused things that in a bunch of cases were hiding better javadocs from the superclass.

I can't tell if Mojang's registry codec madness is clever or if it is braindead after staring at it for too long, it's turning my brain into mush. My best guess is that it is both, in equal proportion.