### PR TITLE
[1.18.x] Fix typo "souce -> source" in EntityBasedExplosionDamageCalculator constructor

### DIFF
--- a/data/net/minecraft/world/level/EntityBasedExplosionDamageCalculator.mapping
+++ b/data/net/minecraft/world/level/EntityBasedExplosionDamageCalculator.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/EntityBasedExplosionDamageCalculator
 	METHOD <init> (Lnet/minecraft/world/entity/Entity;)V
-		ARG 1 souce
+		ARG 1 source
 	METHOD getBlockExplosionResistance (Lnet/minecraft/world/level/Explosion;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/material/FluidState;)Ljava/util/Optional;
 		ARG 1 explosion
 		ARG 2 reader


### PR DESCRIPTION
As pointed out by `Radon#9262` in the [Public Discord](https://discord.parchmentmc.org/)

Introduced during `1.17.x`