### PR TITLE
Refactor worldPosition -> pos, and cleanup some misc. javadocs.

### DIFF
--- a/data/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity
 	METHOD <init> (Lnet/minecraft/world/level/block/entity/BlockEntityType;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/item/crafting/RecipeType;)V
 		ARG 1 type
-		ARG 2 worldPosition
+		ARG 2 pos
 		ARG 3 blockState
 		ARG 4 recipeType
 	METHOD add (Ljava/util/Map;Lnet/minecraft/tags/TagKey;I)V

--- a/data/net/minecraft/world/level/block/entity/BannerBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/BannerBlockEntity.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/world/level/block/entity/BannerBlockEntity
 		ARG 1 worldPosition
 		ARG 2 blockState
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/item/DyeColor;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 		ARG 3 baseColor
 	METHOD createPatterns (Lnet/minecraft/world/item/DyeColor;Lnet/minecraft/nbt/ListTag;)Ljava/util/List;

--- a/data/net/minecraft/world/level/block/entity/BannerBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/BannerBlockEntity.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/world/level/block/entity/BannerBlockEntity
 	FIELD patterns Ljava/util/List;
 		COMMENT A list of all patterns stored on this banner.
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/item/DyeColor;)V
 		ARG 1 pos

--- a/data/net/minecraft/world/level/block/entity/BarrelBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/BarrelBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/BarrelBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD createMenu (ILnet/minecraft/world/entity/player/Inventory;)Lnet/minecraft/world/inventory/AbstractContainerMenu;
 		ARG 1 id

--- a/data/net/minecraft/world/level/block/entity/BeaconBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/BeaconBlockEntity.mapping
@@ -1,18 +1,18 @@
 CLASS net/minecraft/world/level/block/entity/BeaconBlockEntity
 	FIELD BEACON_EFFECTS [[Lnet/minecraft/world/effect/MobEffect;
-		COMMENT List of effects that Beacons can apply
+		COMMENT A list of effects that beacons can apply.
 	FIELD beamSections Ljava/util/List;
-		COMMENT A list of beam segments for this beacon
+		COMMENT A list of beam segments for this beacon.
 	FIELD levels I
-		COMMENT Level of this beacon's pyramid.
+		COMMENT The number of levels of this beacon's pyramid.
 	FIELD name Lnet/minecraft/network/chat/Component;
 		COMMENT The custom name for this beacon.
 	FIELD primaryPower Lnet/minecraft/world/effect/MobEffect;
-		COMMENT Primary MobEffect given by this beacon.
+		COMMENT The primary effect given by this beacon.
 	FIELD secondaryPower Lnet/minecraft/world/effect/MobEffect;
-		COMMENT Secondary MobEffect given by this beacon.
+		COMMENT The secondary effect given by this beacon.
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD applyEffects (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;ILnet/minecraft/world/effect/MobEffect;Lnet/minecraft/world/effect/MobEffect;)V
 		ARG 0 level
@@ -41,8 +41,8 @@ CLASS net/minecraft/world/level/block/entity/BeaconBlockEntity
 			ARG 2 value
 	CLASS BeaconBeamSection
 		FIELD color [F
-			COMMENT RGB (0 to 1.0) colors of this beam segment
+			COMMENT The colors of this section of a beacon beam, in RGB float format.
 		METHOD <init> ([F)V
 			ARG 1 color
 		METHOD getColor ()[F
-			COMMENT @return RGB (0 to 1.0) colors of this beam segment
+			COMMENT @return The colors of this section of a beacon beam, in RGB float format.

--- a/data/net/minecraft/world/level/block/entity/BedBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/BedBlockEntity.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/world/level/block/entity/BedBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/item/DyeColor;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 		ARG 3 color
 	METHOD setColor (Lnet/minecraft/world/item/DyeColor;)V

--- a/data/net/minecraft/world/level/block/entity/BeehiveBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/BeehiveBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/BeehiveBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD addOccupant (Lnet/minecraft/world/entity/Entity;Z)V
 		ARG 1 occupant

--- a/data/net/minecraft/world/level/block/entity/BellBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/BellBlockEntity.mapping
@@ -1,13 +1,14 @@
 CLASS net/minecraft/world/level/block/entity/BellBlockEntity
 	FIELD resonationTicks I
-		COMMENT Warmup counter until raiders are revealed by glow and particle
+		COMMENT A tick counter before raiders are revealed. At {@link #TICKS_BEFORE_RESONATION} ticks, the resonation sound is played, and at {@link #MAX_RESONATION_TICKS}, nearby raiders are revealed.
 	FIELD ticks I
-		COMMENT How long the bell has been ringing
+		COMMENT How many ticks the bell has been ringing.
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
 		ARG 1 pos
 		ARG 2 blockState
 	METHOD areRaidersNearby (Lnet/minecraft/core/BlockPos;Ljava/util/List;)Z
 		ARG 0 pos
+		ARG 1 raiders
 	METHOD clientTick (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/entity/BellBlockEntity;)V
 		ARG 0 level
 		ARG 1 pos
@@ -18,9 +19,18 @@ CLASS net/minecraft/world/level/block/entity/BellBlockEntity
 	METHOD isRaiderWithinRange (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/LivingEntity;)Z
 		ARG 0 pos
 		ARG 1 raider
+	METHOD lambda$makeRaidersGlow$0 (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/LivingEntity;)Z
+		ARG 1 raider
+	METHOD lambda$showBellParticles$1 (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/LivingEntity;)Z
+		ARG 1 raider
+	METHOD lambda$showBellParticles$2 (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/LivingEntity;)Z
+		ARG 1 raider
+	METHOD lambda$showBellParticles$3 (Lnet/minecraft/core/BlockPos;ILorg/apache/commons/lang3/mutable/MutableInt;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/LivingEntity;)V
+		ARG 4 raider
 	METHOD makeRaidersGlow (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Ljava/util/List;)V
 		ARG 0 level
 		ARG 1 pos
+		ARG 2 raiders
 	METHOD onHit (Lnet/minecraft/core/Direction;)V
 		ARG 1 direction
 	METHOD serverTick (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/entity/BellBlockEntity;)V
@@ -28,6 +38,10 @@ CLASS net/minecraft/world/level/block/entity/BellBlockEntity
 		ARG 1 pos
 		ARG 2 state
 		ARG 3 blockEntity
+	METHOD showBellParticles (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Ljava/util/List;)V
+		ARG 0 level
+		ARG 1 pos
+		ARG 2 raiders
 	METHOD tick (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/entity/BellBlockEntity;Lnet/minecraft/world/level/block/entity/BellBlockEntity$ResonationEndAction;)V
 		ARG 0 level
 		ARG 1 pos
@@ -37,3 +51,8 @@ CLASS net/minecraft/world/level/block/entity/BellBlockEntity
 	METHOD triggerEvent (II)Z
 		ARG 1 id
 		ARG 2 type
+	CLASS ResonationEndAction
+		METHOD run (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Ljava/util/List;)V
+			ARG 1 level
+			ARG 2 pos
+			ARG 3 raiders

--- a/data/net/minecraft/world/level/block/entity/BlastFurnaceBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/BlastFurnaceBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/BlastFurnaceBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD createMenu (ILnet/minecraft/world/entity/player/Inventory;)Lnet/minecraft/world/inventory/AbstractContainerMenu;
 		ARG 1 id

--- a/data/net/minecraft/world/level/block/entity/BlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/BlockEntity.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/world/level/block/entity/BlockEntity
 	METHOD <init> (Lnet/minecraft/world/level/block/entity/BlockEntityType;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
 		ARG 1 type
-		ARG 2 worldPosition
+		ARG 2 pos
 		ARG 3 blockState
 	METHOD addEntityType (Lnet/minecraft/nbt/CompoundTag;Lnet/minecraft/world/level/block/entity/BlockEntityType;)V
 		ARG 0 tag
@@ -30,6 +30,8 @@ CLASS net/minecraft/world/level/block/entity/BlockEntity
 		ARG 1 tag
 	METHOD saveMetadata (Lnet/minecraft/nbt/CompoundTag;)V
 		ARG 1 tag
+	METHOD saveToItem (Lnet/minecraft/world/item/ItemStack;)V
+		ARG 1 stack
 	METHOD setBlockState (Lnet/minecraft/world/level/block/state/BlockState;)V
 		ARG 1 blockState
 	METHOD setChanged (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V

--- a/data/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.mapping
@@ -1,8 +1,8 @@
 CLASS net/minecraft/world/level/block/entity/BrewingStandBlockEntity
 	FIELD items Lnet/minecraft/core/NonNullList;
-		COMMENT The ItemStacks currently placed in the slots of the brewing stand
+		COMMENT The items currently placed in the slots of the brewing stand.
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 state
 	METHOD canPlaceItem (ILnet/minecraft/world/item/ItemStack;)Z
 		ARG 1 index

--- a/data/net/minecraft/world/level/block/entity/CampfireBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/CampfireBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/CampfireBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD cookTick (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/entity/CampfireBlockEntity;)V
 		ARG 0 level

--- a/data/net/minecraft/world/level/block/entity/ChestBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/ChestBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/ChestBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD createMenu (ILnet/minecraft/world/entity/player/Inventory;)Lnet/minecraft/world/inventory/AbstractContainerMenu;
 		ARG 1 id

--- a/data/net/minecraft/world/level/block/entity/CommandBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/CommandBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/CommandBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD setAutomatic (Z)V
 		ARG 1 auto
@@ -8,5 +8,4 @@ CLASS net/minecraft/world/level/block/entity/CommandBlockEntity
 		ARG 1 powered
 	CLASS 1
 		METHOD setCommand (Ljava/lang/String;)V
-			COMMENT Sets the command.
 			ARG 1 command

--- a/data/net/minecraft/world/level/block/entity/ComparatorBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/ComparatorBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/ComparatorBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD setOutputSignal (I)V
 		ARG 1 output

--- a/data/net/minecraft/world/level/block/entity/ConduitBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/ConduitBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/ConduitBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD animationTick (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Ljava/util/List;Lnet/minecraft/world/entity/Entity;I)V
 		ARG 0 level

--- a/data/net/minecraft/world/level/block/entity/DaylightDetectorBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/DaylightDetectorBlockEntity.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/world/level/block/entity/DaylightDetectorBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState

--- a/data/net/minecraft/world/level/block/entity/DispenserBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/DispenserBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/DispenserBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD addItem (Lnet/minecraft/world/item/ItemStack;)I
 		COMMENT Add the given ItemStack to this dispenser.

--- a/data/net/minecraft/world/level/block/entity/EnchantmentTableBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/EnchantmentTableBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/EnchantmentTableBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD bookAnimationTick (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/entity/EnchantmentTableBlockEntity;)V
 		ARG 0 level

--- a/data/net/minecraft/world/level/block/entity/EnderChestBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/EnderChestBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/EnderChestBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD getOpenNess (F)F
 		ARG 1 partialTicks

--- a/data/net/minecraft/world/level/block/entity/FurnaceBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/FurnaceBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/FurnaceBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD createMenu (ILnet/minecraft/world/entity/player/Inventory;)Lnet/minecraft/world/inventory/AbstractContainerMenu;
 		ARG 1 id

--- a/data/net/minecraft/world/level/block/entity/HopperBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/HopperBlockEntity.mapping
@@ -59,11 +59,11 @@ CLASS net/minecraft/world/level/block/entity/HopperBlockEntity
 		ARG 0 level
 		ARG 1 hopper
 	METHOD isEmptyContainer (Lnet/minecraft/world/Container;Lnet/minecraft/core/Direction;)Z
-		COMMENT @return whether the given {@link Container} is empty from the given face
+		COMMENT @return whether the given {@code container} is empty from the given face
 		ARG 0 container
 		ARG 1 direction
 	METHOD isFullContainer (Lnet/minecraft/world/Container;Lnet/minecraft/core/Direction;)Z
-		COMMENT @return false if the {@link Container} has any room to place items in
+		COMMENT @return {@code false} if the {@code container} has any room to place items in
 		ARG 0 container
 		ARG 1 direction
 	METHOD lambda$isEmptyContainer$2 (Lnet/minecraft/world/Container;I)Z

--- a/data/net/minecraft/world/level/block/entity/HopperBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/HopperBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/HopperBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD addItem (Lnet/minecraft/world/Container;Lnet/minecraft/world/Container;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/core/Direction;)Lnet/minecraft/world/item/ItemStack;
 		COMMENT Attempts to place the passed stack in the container, using as many slots as required.
@@ -39,8 +39,12 @@ CLASS net/minecraft/world/level/block/entity/HopperBlockEntity
 		ARG 2 state
 		ARG 3 entity
 		ARG 4 blockEntity
+	METHOD getAttachedContainer (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/Container;
+		ARG 0 level
+		ARG 1 pos
+		ARG 2 state
 	METHOD getContainerAt (Lnet/minecraft/world/level/Level;DDD)Lnet/minecraft/world/Container;
-		COMMENT @return the container for the given position or null if none was found
+		COMMENT @return the container for the given position or {@code null} if none was found
 		ARG 0 level
 		ARG 1 x
 		ARG 3 y
@@ -48,12 +52,18 @@ CLASS net/minecraft/world/level/block/entity/HopperBlockEntity
 	METHOD getContainerAt (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/Container;
 		ARG 0 level
 		ARG 1 pos
+	METHOD getItemsAtAndAbove (Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/block/entity/Hopper;)Ljava/util/List;
+		ARG 0 level
+		ARG 1 hopper
+	METHOD getSourceContainer (Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/block/entity/Hopper;)Lnet/minecraft/world/Container;
+		ARG 0 level
+		ARG 1 hopper
 	METHOD isEmptyContainer (Lnet/minecraft/world/Container;Lnet/minecraft/core/Direction;)Z
-		COMMENT @return whether the given Container is empty from the given face
+		COMMENT @return whether the given {@link Container} is empty from the given face
 		ARG 0 container
 		ARG 1 direction
 	METHOD isFullContainer (Lnet/minecraft/world/Container;Lnet/minecraft/core/Direction;)Z
-		COMMENT @return false if the container has any room to place items in
+		COMMENT @return false if the {@link Container} has any room to place items in
 		ARG 0 container
 		ARG 1 direction
 	METHOD lambda$isEmptyContainer$2 (Lnet/minecraft/world/Container;I)Z
@@ -86,7 +96,7 @@ CLASS net/minecraft/world/level/block/entity/HopperBlockEntity
 		ARG 3 blockEntity
 	METHOD tryTakeInItemFromSlot (Lnet/minecraft/world/level/block/entity/Hopper;Lnet/minecraft/world/Container;ILnet/minecraft/core/Direction;)Z
 		COMMENT Pulls from the specified slot in the container and places in any available slot in the hopper.
-		COMMENT @return true if the entire stack was moved
+		COMMENT @return {@code true} if the entire stack was moved.
 		ARG 0 hopper
 		ARG 1 container
 		ARG 2 slot

--- a/data/net/minecraft/world/level/block/entity/JigsawBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/JigsawBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/JigsawBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD generate (Lnet/minecraft/server/level/ServerLevel;IZ)V
 		ARG 1 level

--- a/data/net/minecraft/world/level/block/entity/JukeboxBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/JukeboxBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/JukeboxBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD setRecord (Lnet/minecraft/world/item/ItemStack;)V
 		ARG 1 record

--- a/data/net/minecraft/world/level/block/entity/LecternBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/LecternBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/LecternBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD createCommandSourceStack (Lnet/minecraft/world/entity/player/Player;)Lnet/minecraft/commands/CommandSourceStack;
 		COMMENT Creates a CommandSourceStack for resolving the contents of a book. If the player is null, a CommandSourceStack with the generic name {@code "Lectern"} is used.

--- a/data/net/minecraft/world/level/block/entity/SculkSensorBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/SculkSensorBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/SculkSensorBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD getRedstoneStrengthForDistance (II)I
 		ARG 0 distance

--- a/data/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD <init> (Lnet/minecraft/world/item/DyeColor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
 		ARG 1 color
-		ARG 2 worldPosition
+		ARG 2 pos
 		ARG 3 blockState
 	METHOD canPlaceItemThroughFace (ILnet/minecraft/world/item/ItemStack;Lnet/minecraft/core/Direction;)Z
 		ARG 1 index

--- a/data/net/minecraft/world/level/block/entity/SignBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/SignBlockEntity.mapping
@@ -1,9 +1,11 @@
 CLASS net/minecraft/world/level/block/entity/SignBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD createCommandSourceStack (Lnet/minecraft/server/level/ServerPlayer;)Lnet/minecraft/commands/CommandSourceStack;
 		ARG 1 player
+	METHOD deserializeTextSafe (Ljava/lang/String;)Lnet/minecraft/network/chat/Component;
+		ARG 1 text
 	METHOD executeClickCommands (Lnet/minecraft/server/level/ServerPlayer;)Z
 		ARG 1 level
 	METHOD getMessages (Z)[Lnet/minecraft/network/chat/Component;

--- a/data/net/minecraft/world/level/block/entity/SkullBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/SkullBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/SkullBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD dragonHeadAnimation (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/entity/SkullBlockEntity;)V
 		ARG 0 level

--- a/data/net/minecraft/world/level/block/entity/SmokerBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/SmokerBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/SmokerBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD createMenu (ILnet/minecraft/world/entity/player/Inventory;)Lnet/minecraft/world/inventory/AbstractContainerMenu;
 		ARG 1 id

--- a/data/net/minecraft/world/level/block/entity/SpawnerBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/SpawnerBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/SpawnerBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD clientTick (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/entity/SpawnerBlockEntity;)V
 		ARG 0 level

--- a/data/net/minecraft/world/level/block/entity/StructureBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/StructureBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/StructureBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD createRandom (J)Ljava/util/Random;
 		ARG 0 seed

--- a/data/net/minecraft/world/level/block/entity/TheEndPortalBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/entity/TheEndPortalBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/level/block/entity/TheEndPortalBlockEntity
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD shouldRenderFace (Lnet/minecraft/core/Direction;)Z
 		ARG 1 face

--- a/data/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.mapping
+++ b/data/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.mapping
@@ -1,20 +1,20 @@
 CLASS net/minecraft/world/level/block/piston/PistonMovingBlockEntity
 	FIELD extending Z
-		COMMENT Whether this piston is extending
+		COMMENT Whether this piston is extending.
 	FIELD progressO F
 		COMMENT The extension / retraction progress
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/Direction;ZZ)V
-		ARG 1 worldPosition
+		ARG 1 pos
 		ARG 2 blockState
 		ARG 3 movedState
 		ARG 4 direction
 		ARG 5 extending
 		ARG 6 isSourcePiston
 	METHOD finalTick ()V
-		COMMENT Removes the piston's BlockEntity and stops any movement
+		COMMENT Removes the piston's block entity and stops any movement.
 	METHOD getCollisionShape (Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/phys/shapes/VoxelShape;
 		ARG 1 level
 		ARG 2 pos


### PR DESCRIPTION
Continuing from https://github.com/ParchmentMC/Parchment/pull/136#discussion_r912521702, it was decided to switch `worldPosition` -> `pos`, for the reasons outlined in said comment (consistency with public accessor `getBlockPos` over protected field `worldPosition`, `worldPosition` itself being a weird name only used by block entities, and consistency with other `BlockPos` arguments). This simply makes that change across all existing mapped block entities.

While I was going through these, I edited a few javadocs, expanding, fixing formatting (sentences), or just general cleanup.