### PR TITLE
Fix: Incorrect argument name in net.minecraft.world.inventory.AbstractContainerMenu#clicked & doClick

### DIFF
--- a/data/net/minecraft/world/inventory/AbstractContainerMenu.mapping
+++ b/data/net/minecraft/world/inventory/AbstractContainerMenu.mapping
@@ -39,13 +39,13 @@ CLASS net/minecraft/world/inventory/AbstractContainerMenu
 		ARG 1 player
 		ARG 2 id
 	METHOD clicked (IILnet/minecraft/world/inventory/ClickType;Lnet/minecraft/world/entity/player/Player;)V
-		ARG 1 mouseX
-		ARG 2 mouseY
+		ARG 1 slotId
+		ARG 2 dragType
 		ARG 3 clickType
 		ARG 4 player
 	METHOD doClick (IILnet/minecraft/world/inventory/ClickType;Lnet/minecraft/world/entity/player/Player;)V
-		ARG 1 mouseX
-		ARG 2 mouseY
+		ARG 1 slotId
+		ARG 2 dragType
 		ARG 3 clickType
 		ARG 4 player
 	METHOD findSlot (Lnet/minecraft/world/Container;I)Ljava/util/OptionalInt;

--- a/data/net/minecraft/world/inventory/AbstractContainerMenu.mapping
+++ b/data/net/minecraft/world/inventory/AbstractContainerMenu.mapping
@@ -40,12 +40,12 @@ CLASS net/minecraft/world/inventory/AbstractContainerMenu
 		ARG 2 id
 	METHOD clicked (IILnet/minecraft/world/inventory/ClickType;Lnet/minecraft/world/entity/player/Player;)V
 		ARG 1 slotId
-		ARG 2 dragType
+		ARG 2 button
 		ARG 3 clickType
 		ARG 4 player
 	METHOD doClick (IILnet/minecraft/world/inventory/ClickType;Lnet/minecraft/world/entity/player/Player;)V
 		ARG 1 slotId
-		ARG 2 dragType
+		ARG 2 button
 		ARG 3 clickType
 		ARG 4 player
 	METHOD findSlot (Lnet/minecraft/world/Container;I)Ljava/util/OptionalInt;


### PR DESCRIPTION
I only fixed it on 1.18.x, and there is also same mistake on other branches.