### PR TITLE
Fix javadoc @link tags

### DIFF
--- a/data/net/minecraft/client/gui/MapRenderer.mapping
+++ b/data/net/minecraft/client/gui/MapRenderer.mapping
@@ -31,4 +31,4 @@ CLASS net/minecraft/client/gui/MapRenderer
 		METHOD replaceMapData (Lnet/minecraft/world/level/saveddata/maps/MapItemSavedData;)V
 			ARG 1 data
 		METHOD updateTexture ()V
-			COMMENT Updates a map {@link net.minecraft.client.gui.MapItemRenderer.Instance#mapTexture texture}
+			COMMENT Updates a map texture.

--- a/data/net/minecraft/client/multiplayer/ClientPacketListener.mapping
+++ b/data/net/minecraft/client/multiplayer/ClientPacketListener.mapping
@@ -78,7 +78,7 @@ CLASS net/minecraft/client/multiplayer/ClientPacketListener
 		COMMENT Received from the servers PlayerManager if between 1 and 64 blocks in a chunk are changed. If only one block requires an update, the server sends S23PacketBlockChange and if 64 or more blocks are changed, the server sends S21PacketChunkData
 		ARG 1 packet
 	METHOD handleCommandSuggestions (Lnet/minecraft/network/protocol/game/ClientboundCommandSuggestionsPacket;)V
-		COMMENT This method is only called for manual tab-completion (the {@link net.minecraft.command.arguments.SuggestionProviders#ASK_SERVER minecraft:ask_server} suggestion provider).
+		COMMENT This method is only called for manual tab-completion (the {@link net.minecraft.commands.synchronization.SuggestionProviders#ASK_SERVER minecraft:ask_server} suggestion provider).
 		ARG 1 packet
 	METHOD handleCommands (Lnet/minecraft/network/protocol/game/ClientboundCommandsPacket;)V
 		ARG 1 packet

--- a/data/net/minecraft/client/renderer/blockentity/BannerRenderer.mapping
+++ b/data/net/minecraft/client/renderer/blockentity/BannerRenderer.mapping
@@ -19,6 +19,6 @@ CLASS net/minecraft/client/renderer/blockentity/BannerRenderer
 		ARG 4 flagPart
 		ARG 5 flagMaterial
 		ARG 6 banner
-			COMMENT @param banner if {@code true}, uses banner material; otherwise if {@code false} uses shield material
+			COMMENT if {@code true}, uses banner material; otherwise if {@code false} uses shield material
 		ARG 7 patterns
 		ARG 8 glint

--- a/data/net/minecraft/client/renderer/entity/ItemRenderer.mapping
+++ b/data/net/minecraft/client/renderer/entity/ItemRenderer.mapping
@@ -81,13 +81,13 @@ CLASS net/minecraft/client/renderer/entity/ItemRenderer
 		ARG 3 y
 		ARG 4 bakedModel
 	METHOD renderGuiItemDecorations (Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;II)V
-		ARG 1 fr
+		ARG 1 font
 		ARG 2 stack
 		ARG 3 xPosition
 		ARG 4 yPosition
 	METHOD renderGuiItemDecorations (Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V
 		COMMENT Renders the stack size and/or damage bar for the given ItemStack.
-		ARG 1 fr
+		ARG 1 font
 		ARG 2 stack
 		ARG 3 xPosition
 		ARG 4 yPosition

--- a/data/net/minecraft/network/protocol/PacketUtils.mapping
+++ b/data/net/minecraft/network/protocol/PacketUtils.mapping
@@ -1,14 +1,14 @@
 CLASS net/minecraft/network/protocol/PacketUtils
 	METHOD ensureRunningOnSameThread (Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;Lnet/minecraft/server/level/ServerLevel;)V
 		COMMENT Ensures that the given packet is handled on the main thread. If the current thread is not the main thread, this method
-		COMMENT throws {@link RunningOnDifferentThreadException}, which is caught and ignored in the outer call ({@link net.minecraft.network.Connection#channelRead0}). Additionally it then re-schedules the packet to be handled on the main thread,
+		COMMENT throws {@link net.minecraft.server.RunningOnDifferentThreadException}, which is caught and ignored in the outer call ({@link net.minecraft.network.Connection#channelRead0(io.netty.channel.ChannelHandlerContext, net.minecraft.network.protocol.Packet)}). Additionally it then re-schedules the packet to be handled on the main thread,
 		COMMENT which will then end up back here, but this time on the main thread.
 		ARG 0 packet
 		ARG 1 processor
 		ARG 2 level
 	METHOD ensureRunningOnSameThread (Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;Lnet/minecraft/util/thread/BlockableEventLoop;)V
 		COMMENT Ensures that the given packet is handled on the main thread. If the current thread is not the main thread, this method
-		COMMENT throws {@link RunningOnDifferentThreadException}, which is caught and ignored in the outer call ({@link net.minecraft.network.Connection#channelRead0}). Additionally it then re-schedules the packet to be handled on the main thread,
+		COMMENT throws {@link net.minecraft.server.RunningOnDifferentThreadException}, which is caught and ignored in the outer call ({@link net.minecraft.network.Connection#channelRead0(io.netty.channel.ChannelHandlerContext, net.minecraft.network.protocol.Packet)}). Additionally it then re-schedules the packet to be handled on the main thread,
 		COMMENT which will then end up back here, but this time on the main thread.
 		ARG 0 packet
 		ARG 1 processor

--- a/data/net/minecraft/network/protocol/game/ClientGamePacketListener.mapping
+++ b/data/net/minecraft/network/protocol/game/ClientGamePacketListener.mapping
@@ -44,7 +44,7 @@ CLASS net/minecraft/network/protocol/game/ClientGamePacketListener
 		COMMENT Received from the servers PlayerManager if between 1 and 64 blocks in a chunk are changed. If only one block requires an update, the server sends S23PacketBlockChange and if 64 or more blocks are changed, the server sends S21PacketChunkData
 		ARG 1 packet
 	METHOD handleCommandSuggestions (Lnet/minecraft/network/protocol/game/ClientboundCommandSuggestionsPacket;)V
-		COMMENT This method is only called for manual tab-completion (the {@link net.minecraft.command.arguments.SuggestionProviders#ASK_SERVER minecraft:ask_server} suggestion provider).
+		COMMENT This method is only called for manual tab-completion (the {@link net.minecraft.commands.synchronization.SuggestionProviders#ASK_SERVER minecraft:ask_server} suggestion provider).
 		ARG 1 packet
 	METHOD handleCommands (Lnet/minecraft/network/protocol/game/ClientboundCommandsPacket;)V
 		ARG 1 packet

--- a/data/net/minecraft/network/protocol/game/ServerGamePacketListener.mapping
+++ b/data/net/minecraft/network/protocol/game/ServerGamePacketListener.mapping
@@ -33,7 +33,7 @@ CLASS net/minecraft/network/protocol/game/ServerGamePacketListener
 		COMMENT Processes the client closing windows (container)
 		ARG 1 packet
 	METHOD handleCustomCommandSuggestions (Lnet/minecraft/network/protocol/game/ServerboundCommandSuggestionPacket;)V
-		COMMENT This method is only called for manual tab-completion (the {@link net.minecraft.command.arguments.SuggestionProviders#ASK_SERVER minecraft:ask_server} suggestion provider).
+		COMMENT This method is only called for manual tab-completion (the {@link net.minecraft.commands.synchronization.SuggestionProviders#ASK_SERVER minecraft:ask_server} suggestion provider).
 		ARG 1 packet
 	METHOD handleCustomPayload (Lnet/minecraft/network/protocol/game/ServerboundCustomPayloadPacket;)V
 		COMMENT Synchronizes serverside and clientside book contents and signing

--- a/data/net/minecraft/server/level/ChunkMap.mapping
+++ b/data/net/minecraft/server/level/ChunkMap.mapping
@@ -98,11 +98,11 @@ CLASS net/minecraft/server/level/ChunkMap
 	METHOD tick (Ljava/util/function/BooleanSupplier;)V
 		ARG 1 hasMoreTime
 	METHOD updateChunkScheduling (JILnet/minecraft/server/level/ChunkHolder;I)Lnet/minecraft/server/level/ChunkHolder;
-		COMMENT Sets level and loads/unloads chunk. Used by {@link net.minecraft.world.server.ChunkManager.ProxyTicketManager} to set chunk level.
+		COMMENT Sets level and loads/unloads chunk.
 		ARG 1 chunkPos
 		ARG 3 newLevel
 		ARG 4 holder
-			COMMENT The {@link net.minecraft.world.server.ChunkHolder} of the chunk if it is loaded, and null otherwise.
+			COMMENT The {@link net.minecraft.server.level.ChunkHolder} of the chunk if it is loaded, and null otherwise.
 		ARG 5 oldLevel
 	METHOD updateChunkTracking (Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/level/ChunkPos;Lorg/apache/commons/lang3/mutable/MutableObject;ZZ)V
 		COMMENT Sends the chunk to the client, or tells it to unload it.

--- a/data/net/minecraft/server/network/ServerGamePacketListenerImpl.mapping
+++ b/data/net/minecraft/server/network/ServerGamePacketListenerImpl.mapping
@@ -65,7 +65,7 @@ CLASS net/minecraft/server/network/ServerGamePacketListenerImpl
 		COMMENT Processes the client closing windows (container)
 		ARG 1 packet
 	METHOD handleCustomCommandSuggestions (Lnet/minecraft/network/protocol/game/ServerboundCommandSuggestionPacket;)V
-		COMMENT This method is only called for manual tab-completion (the {@link net.minecraft.command.arguments.SuggestionProviders#ASK_SERVER minecraft:ask_server} suggestion provider).
+		COMMENT This method is only called for manual tab-completion (the {@link net.minecraft.commands.synchronization.SuggestionProviders#ASK_SERVER minecraft:ask_server} suggestion provider).
 		ARG 1 packet
 	METHOD handleCustomPayload (Lnet/minecraft/network/protocol/game/ServerboundCustomPayloadPacket;)V
 		COMMENT Synchronizes serverside and clientside book contents and signing

--- a/data/net/minecraft/world/damagesource/CombatEntry.mapping
+++ b/data/net/minecraft/world/damagesource/CombatEntry.mapping
@@ -9,4 +9,4 @@ CLASS net/minecraft/world/damagesource/CombatEntry
 	METHOD getSource ()Lnet/minecraft/world/damagesource/DamageSource;
 		COMMENT Get the DamageSource of the CombatEntry instance.
 	METHOD isCombatRelated ()Z
-		COMMENT Returns true if {@link net.minecraft.util.DamageSource#getEntity() damage source} is a living entity
+		COMMENT Returns true if {@link net.minecraft.world.damagesource.DamageSource#getEntity() damage source} is a living entity

--- a/data/net/minecraft/world/entity/Entity.mapping
+++ b/data/net/minecraft/world/entity/Entity.mapping
@@ -227,7 +227,7 @@ CLASS net/minecraft/world/entity/Entity
 	METHOD getZ (D)D
 		ARG 1 scale
 	METHOD handleEntityEvent (B)V
-		COMMENT Handles an entity event fired from {@link net.minecraft.world.level.Level#broadcastEntityEvent}.
+		COMMENT Handles an entity event received from a {@link net.minecraft.network.protocol.game.ClientboundEntityEventPacket}.
 		ARG 1 id
 	METHOD handleInsidePortal (Lnet/minecraft/core/BlockPos;)V
 		COMMENT Marks the entity as being inside a portal, activating teleportation logic in onEntityUpdate() in the following tick(s).
@@ -424,7 +424,7 @@ CLASS net/minecraft/world/entity/Entity
 	METHOD onSyncedDataUpdated (Lnet/minecraft/network/syncher/EntityDataAccessor;)V
 		ARG 1 key
 	METHOD onlyOpCanSetNbt ()Z
-		COMMENT Checks if players can use this entity to access operator (permission level 2) commands either directly or indirectly, such as give or setblock. A similar method exists for entities at {@link net.minecraft.tileentity.TileEntity#onlyOpsCanSetNbt()}.<p>For example, {@link net.minecraft.entity.item.EntityMinecartCommandBlock#ignoreItemEntityData() command block minecarts} and {@link net.minecraft.entity.item.EntityMinecartMobSpawner#ignoreItemEntityData() mob spawner minecarts} (spawning command block minecarts or drops) are considered accessible.</p>@return true if this entity offers ways for unauthorized players to use restricted commands
+		COMMENT Checks if players can use this entity to access operator (permission level 2) commands either directly or indirectly, such as give or setblock. A similar method exists for entities at {@link net.minecraft.world.entity.Entity#onlyOpCanSetNbt()}.<p>For example, {@link net.minecraft.world.entity.vehicle.MinecartCommandBlock#onlyOpCanSetNbt() command block minecarts} and {@link net.minecraft.world.entity.vehicle.MinecartSpawner#onlyOpCanSetNbt() mob spawner minecarts} (spawning command block minecarts or drops) are considered accessible.</p>@return true if this entity offers ways for unauthorized players to use restricted commands
 	METHOD outOfWorld ()V
 		COMMENT sets the dead flag. Used when you fall off the bottom of the world.
 	METHOD pick (DFZ)Lnet/minecraft/world/phys/HitResult;

--- a/data/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.mapping
+++ b/data/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.mapping
@@ -17,7 +17,7 @@ CLASS net/minecraft/world/entity/ai/goal/MoveToBlockGoal
 	METHOD canUse ()Z
 		COMMENT Returns whether execution should begin. You can also read and cache any state necessary for execution in this method as well.
 	METHOD findNearestBlock ()Z
-		COMMENT Searches and sets new destination block and returns true if a suitable block (specified in {@link net.minecraft.entity.ai.EntityAIMoveToBlock#shouldMoveTo(World, BlockPos) EntityAIMoveToBlock#shouldMoveTo(World, BlockPos)}) can be found.
+		COMMENT Searches and sets new destination block and returns true if a suitable block (specified in {@link #isValidTarget(net.minecraft.world.level.LevelReader, net.minecraft.core.BlockPos)}) can be found.
 	METHOD isValidTarget (Lnet/minecraft/world/level/LevelReader;Lnet/minecraft/core/BlockPos;)Z
 		COMMENT Return true to set given position as destination
 		ARG 1 level

--- a/data/net/minecraft/world/entity/ai/navigation/PathNavigation.mapping
+++ b/data/net/minecraft/world/entity/ai/navigation/PathNavigation.mapping
@@ -52,7 +52,7 @@ CLASS net/minecraft/world/entity/ai/navigation/PathNavigation
 	METHOD createPathFinder (I)Lnet/minecraft/world/level/pathfinder/PathFinder;
 		ARG 1 maxVisitedNodes
 	METHOD doStuckDetection (Lnet/minecraft/world/phys/Vec3;)V
-		COMMENT Checks if entity haven't been moved when last checked and if so, clears current {@link net.minecraft.pathfinding.PathEntity}
+		COMMENT Checks if entity haven't been moved when last checked and if so, stops the current navigation.
 		ARG 1 positionVec3
 	METHOD getGroundY (Lnet/minecraft/world/phys/Vec3;)D
 		ARG 1 vec

--- a/data/net/minecraft/world/entity/animal/Rabbit.mapping
+++ b/data/net/minecraft/world/entity/animal/Rabbit.mapping
@@ -43,7 +43,7 @@ CLASS net/minecraft/world/entity/animal/Rabbit
 	METHOD setSpeedModifier (D)V
 		ARG 1 speedModifier
 	METHOD wantsMoreFood ()Z
-		COMMENT Returns true if {@link net.minecraft.entity.passive.EntityRabbit#carrotTicks carrotTicks} has reached zero
+		COMMENT Returns true if {@link #moreCarrotTicks} has reached zero
 	CLASS RaidGardenGoal
 		METHOD <init> (Lnet/minecraft/world/entity/animal/Rabbit;)V
 			ARG 1 rabbit

--- a/data/net/minecraft/world/entity/item/FallingBlockEntity.mapping
+++ b/data/net/minecraft/world/entity/item/FallingBlockEntity.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/world/entity/item/FallingBlockEntity
 	METHOD lambda$causeFallDamage$0 (Lnet/minecraft/world/damagesource/DamageSource;FLnet/minecraft/world/entity/Entity;)V
 		ARG 2 entity
 	METHOD onlyOpCanSetNbt ()Z
-		COMMENT Checks if players can use this entity to access operator (permission level 2) commands either directly or indirectly, such as give or setblock. A similar method exists for entities at {@link net.minecraft.tileentity.TileEntity#onlyOpsCanSetNbt()}.<p>For example, {@link net.minecraft.entity.item.EntityMinecartCommandBlock#ignoreItemEntityData() command block minecarts} and {@link net.minecraft.entity.item.EntityMinecartMobSpawner#ignoreItemEntityData() mob spawner minecarts} (spawning command block minecarts or drops) are considered accessible.</p>@return true if this entity offers ways for unauthorized players to use restricted commands
+		COMMENT Checks if players can use this entity to access operator (permission level 2) commands either directly or indirectly, such as give or setblock. A similar method exists for entities at {@link net.minecraft.world.entity.Entity#onlyOpCanSetNbt()}.<p>For example, {@link net.minecraft.world.entity.vehicle.MinecartCommandBlock#onlyOpCanSetNbt() command block minecarts} and {@link net.minecraft.world.entity.vehicle.MinecartSpawner#onlyOpCanSetNbt() mob spawner minecarts} (spawning command block minecarts or drops) are considered accessible.</p>@return true if this entity offers ways for unauthorized players to use restricted commands
 	METHOD readAdditionalSaveData (Lnet/minecraft/nbt/CompoundTag;)V
 		COMMENT (abstract) Protected helper method to read subclass entity data from NBT.
 		ARG 1 compound

--- a/data/net/minecraft/world/entity/npc/Villager.mapping
+++ b/data/net/minecraft/world/entity/npc/Villager.mapping
@@ -33,7 +33,7 @@ CLASS net/minecraft/world/entity/npc/Villager
 		ARG 2 target
 		ARG 3 gameTime
 	METHOD hasExcessFood ()Z
-		COMMENT Used by {@link net.minecraft.entity.ai.EntityAIVillagerInteract EntityAIVillagerInteract} to check if the villager can give some items from an inventory to another villager.
+		COMMENT Used by {@link net.minecraft.world.entity.ai.behavior.TradeWithVillager} to check if the villager can give some items from an inventory to another villager.
 	METHOD hasFarmSeeds ()Z
 		COMMENT Returns true if villager has seeds, potatoes or carrots in inventory
 	METHOD makeBrain (Lcom/mojang/serialization/Dynamic;)Lnet/minecraft/world/entity/ai/Brain;

--- a/data/net/minecraft/world/entity/vehicle/MinecartCommandBlock.mapping
+++ b/data/net/minecraft/world/entity/vehicle/MinecartCommandBlock.mapping
@@ -20,7 +20,7 @@ CLASS net/minecraft/world/entity/vehicle/MinecartCommandBlock
 	METHOD onSyncedDataUpdated (Lnet/minecraft/network/syncher/EntityDataAccessor;)V
 		ARG 1 key
 	METHOD onlyOpCanSetNbt ()Z
-		COMMENT Checks if players can use this entity to access operator (permission level 2) commands either directly or indirectly, such as give or setblock. A similar method exists for entities at {@link net.minecraft.tileentity.TileEntity#onlyOpsCanSetNbt()}.<p>For example, {@link net.minecraft.entity.item.EntityMinecartCommandBlock#ignoreItemEntityData() command block minecarts} and {@link net.minecraft.entity.item.EntityMinecartMobSpawner#ignoreItemEntityData() mob spawner minecarts} (spawning command block minecarts or drops) are considered accessible.</p>@return true if this entity offers ways for unauthorized players to use restricted commands
+		COMMENT Checks if players can use this entity to access operator (permission level 2) commands either directly or indirectly, such as give or setblock. A similar method exists for entities at {@link net.minecraft.world.entity.Entity#onlyOpCanSetNbt()}.<p>For example, {@link net.minecraft.world.entity.vehicle.MinecartCommandBlock#onlyOpCanSetNbt() command block minecarts} and {@link net.minecraft.world.entity.vehicle.MinecartSpawner#onlyOpCanSetNbt() mob spawner minecarts} (spawning command block minecarts or drops) are considered accessible.</p>@return true if this entity offers ways for unauthorized players to use restricted commands
 	METHOD readAdditionalSaveData (Lnet/minecraft/nbt/CompoundTag;)V
 		COMMENT (abstract) Protected helper method to read subclass entity data from NBT.
 		ARG 1 compound

--- a/data/net/minecraft/world/entity/vehicle/MinecartSpawner.mapping
+++ b/data/net/minecraft/world/entity/vehicle/MinecartSpawner.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/world/entity/vehicle/MinecartSpawner
 	METHOD createTicker (Lnet/minecraft/world/level/Level;)Ljava/lang/Runnable;
 		ARG 1 level
 	METHOD onlyOpCanSetNbt ()Z
-		COMMENT Checks if players can use this entity to access operator (permission level 2) commands either directly or indirectly, such as give or setblock. A similar method exists for entities at {@link net.minecraft.tileentity.TileEntity#onlyOpsCanSetNbt()}.<p>For example, {@link net.minecraft.entity.item.EntityMinecartCommandBlock#ignoreItemEntityData() command block minecarts} and {@link net.minecraft.entity.item.EntityMinecartMobSpawner#ignoreItemEntityData() mob spawner minecarts} (spawning command block minecarts or drops) are considered accessible.</p>@return true if this entity offers ways for unauthorized players to use restricted commands
+		COMMENT Checks if players can use this entity to access operator (permission level 2) commands either directly or indirectly, such as give or setblock. A similar method exists for entities at {@link net.minecraft.world.entity.Entity#onlyOpCanSetNbt()}.<p>For example, {@link net.minecraft.world.entity.vehicle.MinecartCommandBlock#onlyOpCanSetNbt() command block minecarts} and {@link net.minecraft.world.entity.vehicle.MinecartSpawner#onlyOpCanSetNbt() mob spawner minecarts} (spawning command block minecarts or drops) are considered accessible.</p>@return true if this entity offers ways for unauthorized players to use restricted commands
 	METHOD readAdditionalSaveData (Lnet/minecraft/nbt/CompoundTag;)V
 		COMMENT (abstract) Protected helper method to read subclass entity data from NBT.
 		ARG 1 compound

--- a/data/net/minecraft/world/item/Item.mapping
+++ b/data/net/minecraft/world/item/Item.mapping
@@ -151,7 +151,7 @@ CLASS net/minecraft/world/item/Item
 	METHOD shouldOverrideMultiplayerNbt ()Z
 		COMMENT If this function returns true (or the item is damageable), the ItemStack's NBT tag will be sent to the client.
 	METHOD use (Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/InteractionResultHolder;
-		COMMENT Called to trigger the item's "innate" right click behavior. To handle when this item is used on a Block, see {@link net.minecraft.world.item.Item#useOn}.
+		COMMENT Called to trigger the item's "innate" right click behavior. To handle when this item is used on a Block, see {@link net.minecraft.world.item.Item#useOn(net.minecraft.world.item.context.UseOnContext)}.
 		ARG 1 level
 		ARG 2 player
 		ARG 3 usedHand

--- a/data/net/minecraft/world/level/biome/BiomeManager.mapping
+++ b/data/net/minecraft/world/level/biome/BiomeManager.mapping
@@ -31,7 +31,7 @@ CLASS net/minecraft/world/level/biome/BiomeManager
 	CLASS NoiseBiomeSource
 		METHOD getNoiseBiome (III)Lnet/minecraft/core/Holder;
 			COMMENT Gets the biome at the given quart positions.
-			COMMENT Note that the coordinates passed into this method are 1/4 the scale of block coordinates. The noise biome is then used by the {@link net.minecraft.world.level.biome.BiomeZoomer} to produce a biome for each unique position, whilst only saving the biomes once per each 4x4x4 cube.
+			COMMENT Note that the coordinates passed into this method are 1/4 the scale of block coordinates.
 			ARG 1 x
 			ARG 2 y
 			ARG 3 z

--- a/data/net/minecraft/world/level/block/Block.mapping
+++ b/data/net/minecraft/world/level/block/Block.mapping
@@ -206,7 +206,7 @@ CLASS net/minecraft/world/level/block/Block
 		ARG 1 level
 		ARG 2 pos
 	METHOD updateOrDestroy (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;I)V
-		COMMENT Replaces oldState with newState, possibly playing effects and creating drops. Flags are as in {@link net.minecraft.world.level.Level#setBlock}
+		COMMENT Replaces oldState with newState, possibly playing effects and creating drops. Flags are as in {@link net.minecraft.world.level.Level#setBlock(net.minecraft.core.BlockPos, net.minecraft.world.level.block.state.BlockState, int)}.
 		ARG 0 oldState
 		ARG 1 newState
 		ARG 2 level

--- a/data/net/minecraft/world/level/block/state/BlockBehaviour.mapping
+++ b/data/net/minecraft/world/level/block/state/BlockBehaviour.mapping
@@ -26,7 +26,7 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 3 pos
 		ARG 4 entity
 	METHOD getAnalogOutputSignal (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)I
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#getAnalogOutputSignal} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getAnalogOutputSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos
@@ -41,13 +41,13 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 4 context
 	METHOD getDestroyProgress (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)F
 		COMMENT Get the hardness of this Block relative to the ability of the given player
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#getDestroyProgress} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getDestroyProgress} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 player
 		ARG 3 level
 		ARG 4 pos
 	METHOD getDirectSignal (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;)I
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#getDirectSignal} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getDirectSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos
@@ -74,11 +74,11 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 2 level
 		ARG 3 pos
 	METHOD getPistonPushReaction (Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/material/PushReaction;
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#getPistonPushReaction} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getPistonPushReaction} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 	METHOD getRenderShape (Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/block/RenderShape;
 		COMMENT The type of render function called. MODEL for mixed tesr and static model, MODELBLOCK_ANIMATED for TESR-only, LIQUID for vanilla liquids, INVISIBLE to skip all rendering
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#getRenderShape} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getRenderShape} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 	METHOD getSeed (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;)J
 		COMMENT Return a random long to be passed to {@link net.minecraft.client.resources.model.BakedModel#getQuads}, used for random model rotations
@@ -94,7 +94,7 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 3 pos
 		ARG 4 context
 	METHOD getSignal (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;)I
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#getSignal} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos
@@ -105,7 +105,7 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 3 pos
 		ARG 4 context
 	METHOD hasAnalogOutputSignal (Lnet/minecraft/world/level/block/state/BlockState;)Z
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#hasAnalogOutputSignal} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#hasAnalogOutputSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 	METHOD isCollisionShapeFullBlock (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z
 		ARG 1 state
@@ -118,11 +118,11 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 4 type
 	METHOD isSignalSource (Lnet/minecraft/world/level/block/state/BlockState;)Z
 		COMMENT Can this block provide power. Only wire currently seems to have this change based on its state.
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#isSignalSource} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#isSignalSource} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 	METHOD mirror (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/Mirror;)Lnet/minecraft/world/level/block/state/BlockState;
 		COMMENT Returns the blockstate with the given mirror of the passed blockstate. If inapplicable, returns the passed blockstate.
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#mirror} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#mirror} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 mirror
 	METHOD neighborChanged (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Block;Lnet/minecraft/core/BlockPos;Z)V
@@ -157,7 +157,7 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 4 random
 	METHOD rotate (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/block/state/BlockState;
 		COMMENT Returns the blockstate with the given rotation from the passed blockstate. If inapplicable, returns the passed blockstate.
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#rotate} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#rotate} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 rotation
 	METHOD skipRendering (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/Direction;)Z
@@ -178,7 +178,7 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 4 random
 	METHOD triggerEvent (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;II)Z
 		COMMENT Called on server when {@link net.minecraft.world.level.Level#blockEvent} is called. If server returns true, then also called on the client. On the Server, this may perform additional changes to the world, like pistons replacing the block with an extended base. On the client, the update may involve replacing tile entities or effects such as sounds or particles
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehavior.BlockStateBase#onBlockEventReceived} whenever possible. Implementing/overriding is fine.
+		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#triggerEvent} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos

--- a/data/net/minecraft/world/level/pathfinder/FlyNodeEvaluator.mapping
+++ b/data/net/minecraft/world/level/pathfinder/FlyNodeEvaluator.mapping
@@ -1,7 +1,6 @@
 CLASS net/minecraft/world/level/pathfinder/FlyNodeEvaluator
 	METHOD done ()V
 		COMMENT This method is called when all nodes have been processed and PathEntity is created.
-		COMMENT {@link net.minecraft.world.pathfinder.WalkNodeProcessor WalkNodeProcessor} uses this to change its field {@link net.minecraft.world.pathfinder.WalkNodeProcessor#avoidsWater avoidsWater}
 	METHOD getBlockPathType (Lnet/minecraft/world/level/BlockGetter;III)Lnet/minecraft/world/level/pathfinder/BlockPathTypes;
 		COMMENT Returns the node type at the specified postion taking the block below into account
 		ARG 1 level

--- a/data/net/minecraft/world/level/pathfinder/NodeEvaluator.mapping
+++ b/data/net/minecraft/world/level/pathfinder/NodeEvaluator.mapping
@@ -1,7 +1,6 @@
 CLASS net/minecraft/world/level/pathfinder/NodeEvaluator
 	METHOD done ()V
 		COMMENT This method is called when all nodes have been processed and PathEntity is created.
-		COMMENT {@link net.minecraft.world.pathfinder.WalkNodeProcessor WalkNodeProcessor} uses this to change its field {@link net.minecraft.world.pathfinder.WalkNodeProcessor#avoidsWater avoidsWater}
 	METHOD getBlockPathType (Lnet/minecraft/world/level/BlockGetter;III)Lnet/minecraft/world/level/pathfinder/BlockPathTypes;
 		COMMENT Returns the node type at the specified postion taking the block below into account
 		ARG 1 level

--- a/data/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.mapping
+++ b/data/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.mapping
@@ -6,7 +6,6 @@ CLASS net/minecraft/world/level/pathfinder/WalkNodeEvaluator
 		ARG 2 nodeType
 	METHOD done ()V
 		COMMENT This method is called when all nodes have been processed and PathEntity is created.
-		COMMENT {@link net.minecraft.world.pathfinder.WalkNodeProcessor WalkNodeProcessor} uses this to change its field {@link net.minecraft.world.pathfinder.WalkNodeProcessor#avoidsWater avoidsWater}
 	METHOD evaluateBlockPathType (Lnet/minecraft/world/level/BlockGetter;ZZLnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/pathfinder/BlockPathTypes;)Lnet/minecraft/world/level/pathfinder/BlockPathTypes;
 		COMMENT Returns the exact path node type according to abilities and settings of the entity
 		ARG 1 level


### PR DESCRIPTION
This fixes old `@link` tags that re no longer valid because classes were renamed or removed. Outdated javadocs have been removed, others have been adjusted to have valid `@link` tags.