### PR TITLE
[1.19.x] Minor update for class changes

### DIFF
--- a/data/net/minecraft/client/player/LocalPlayer.mapping
+++ b/data/net/minecraft/client/player/LocalPlayer.mapping
@@ -93,8 +93,6 @@ CLASS net/minecraft/client/player/LocalPlayer
 		ARG 1 commandBlock
 	METHOD openStructureBlock (Lnet/minecraft/world/level/block/entity/StructureBlockEntity;)V
 		ARG 1 structure
-	METHOD openTextEdit (Lnet/minecraft/world/level/block/entity/SignBlockEntity;)V
-		ARG 1 signTile
 	METHOD playSound (Lnet/minecraft/sounds/SoundEvent;FF)V
 		ARG 1 sound
 		ARG 2 volume

--- a/data/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.mapping
+++ b/data/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket
 	FIELD type Lnet/minecraft/world/level/block/entity/BlockEntityType;
-		COMMENT Used only for vanilla tile entities
+		COMMENT Used only for vanilla block entities
 	METHOD <init> (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/entity/BlockEntityType;Lnet/minecraft/nbt/CompoundTag;)V
 		ARG 1 pos
 		ARG 2 type

--- a/data/net/minecraft/server/level/ServerPlayer.mapping
+++ b/data/net/minecraft/server/level/ServerPlayer.mapping
@@ -130,8 +130,6 @@ CLASS net/minecraft/server/level/ServerPlayer
 	METHOD openItemGui (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/InteractionHand;)V
 		ARG 1 stack
 		ARG 2 hand
-	METHOD openTextEdit (Lnet/minecraft/world/level/block/entity/SignBlockEntity;)V
-		ARG 1 signTile
 	METHOD processPortalCooldown ()V
 		COMMENT Decrements the counter for the remaining time until the entity may use a portal again.
 	METHOD readAdditionalSaveData (Lnet/minecraft/nbt/CompoundTag;)V

--- a/data/net/minecraft/world/CompoundContainer.mapping
+++ b/data/net/minecraft/world/CompoundContainer.mapping
@@ -24,7 +24,7 @@ CLASS net/minecraft/world/CompoundContainer
 		COMMENT Removes a stack from the given slot and returns it.
 		ARG 1 index
 	METHOD setChanged ()V
-		COMMENT For tile entities, ensures the chunk containing the tile entity is saved to disk later - the game won't think it hasn't changed and skip it.
+		COMMENT For block entities, ensures the chunk containing the block entity is saved to disk later - the game won't think it hasn't changed and skip it.
 	METHOD setItem (ILnet/minecraft/world/item/ItemStack;)V
 		COMMENT Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
 		ARG 1 index

--- a/data/net/minecraft/world/Container.mapping
+++ b/data/net/minecraft/world/Container.mapping
@@ -24,7 +24,7 @@ CLASS net/minecraft/world/Container
 		COMMENT Removes a stack from the given slot and returns it.
 		ARG 1 slot
 	METHOD setChanged ()V
-		COMMENT For tile entities, ensures the chunk containing the tile entity is saved to disk later - the game won't think it hasn't changed and skip it.
+		COMMENT For block entities, ensures the chunk containing the block entity is saved to disk later - the game won't think it hasn't changed and skip it.
 	METHOD setItem (ILnet/minecraft/world/item/ItemStack;)V
 		COMMENT Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
 		ARG 1 slot

--- a/data/net/minecraft/world/SimpleContainer.mapping
+++ b/data/net/minecraft/world/SimpleContainer.mapping
@@ -44,7 +44,7 @@ CLASS net/minecraft/world/SimpleContainer
 		COMMENT Removes the specified {@link net.minecraft.world.ContainerListener} from receiving further change notices.
 		ARG 1 listener
 	METHOD setChanged ()V
-		COMMENT For tile entities, ensures the chunk containing the tile entity is saved to disk later - the game won't think it hasn't changed and skip it.
+		COMMENT For block entities, ensures the chunk containing the block entity is saved to disk later - the game won't think it hasn't changed and skip it.
 	METHOD setItem (ILnet/minecraft/world/item/ItemStack;)V
 		COMMENT Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
 		ARG 1 index

--- a/data/net/minecraft/world/entity/player/Inventory.mapping
+++ b/data/net/minecraft/world/entity/player/Inventory.mapping
@@ -86,7 +86,7 @@ CLASS net/minecraft/world/entity/player/Inventory
 		COMMENT Writes the inventory out as a list of compound tags. This is where the slot indices are used (+100 for armor, +80 for crafting).
 		ARG 1 listTag
 	METHOD setChanged ()V
-		COMMENT For tile entities, ensures the chunk containing the tile entity is saved to disk later - the game won't think it hasn't changed and skip it.
+		COMMENT For block entities, ensures the chunk containing the block entity is saved to disk later - the game won't think it hasn't changed and skip it.
 	METHOD setItem (ILnet/minecraft/world/item/ItemStack;)V
 		COMMENT Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
 		ARG 1 index

--- a/data/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.mapping
+++ b/data/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.mapping
@@ -29,7 +29,7 @@ CLASS net/minecraft/world/entity/vehicle/AbstractMinecartContainer
 		COMMENT Removes a stack from the given slot and returns it.
 		ARG 1 index
 	METHOD setChanged ()V
-		COMMENT For tile entities, ensures the chunk containing the tile entity is saved to disk later - the game won't think it hasn't changed and skip it.
+		COMMENT For block entities, ensures the chunk containing the block entity is saved to disk later - the game won't think it hasn't changed and skip it.
 	METHOD setItem (ILnet/minecraft/world/item/ItemStack;)V
 		COMMENT Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
 		ARG 1 index

--- a/data/net/minecraft/world/inventory/AbstractContainerMenu.mapping
+++ b/data/net/minecraft/world/inventory/AbstractContainerMenu.mapping
@@ -69,7 +69,7 @@ CLASS net/minecraft/world/inventory/AbstractContainerMenu
 		COMMENT Extracts the drag mode. Args : eventButton. Return (0 : evenly split, 1 : one item by slot, 2 : not used ?)
 		ARG 0 eventButton
 	METHOD getRedstoneSignalFromBlockEntity (Lnet/minecraft/world/level/block/entity/BlockEntity;)I
-		COMMENT Like the version that takes an inventory. If the given TileEntity is not an Inventory, 0 is returned instead.
+		COMMENT Like the version that takes an inventory. If the given BlockEntity is not an Inventory, 0 is returned instead.
 		ARG 0 blockEntity
 	METHOD getRedstoneSignalFromContainer (Lnet/minecraft/world/Container;)I
 		ARG 0 container

--- a/data/net/minecraft/world/inventory/CraftingContainer.mapping
+++ b/data/net/minecraft/world/inventory/CraftingContainer.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/world/inventory/CraftingContainer
 		COMMENT Removes a stack from the given slot and returns it.
 		ARG 1 index
 	METHOD setChanged ()V
-		COMMENT For tile entities, ensures the chunk containing the tile entity is saved to disk later - the game won't think it hasn't changed and skip it.
+		COMMENT For block entities, ensures the chunk containing the block entity is saved to disk later - the game won't think it hasn't changed and skip it.
 	METHOD setItem (ILnet/minecraft/world/item/ItemStack;)V
 		COMMENT Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
 		ARG 1 index

--- a/data/net/minecraft/world/inventory/MerchantContainer.mapping
+++ b/data/net/minecraft/world/inventory/MerchantContainer.mapping
@@ -17,7 +17,7 @@ CLASS net/minecraft/world/inventory/MerchantContainer
 		COMMENT Removes a stack from the given slot and returns it.
 		ARG 1 index
 	METHOD setChanged ()V
-		COMMENT For tile entities, ensures the chunk containing the tile entity is saved to disk later - the game won't think it hasn't changed and skip it.
+		COMMENT For block entities, ensures the chunk containing the block entity is saved to disk later - the game won't think it hasn't changed and skip it.
 	METHOD setItem (ILnet/minecraft/world/item/ItemStack;)V
 		COMMENT Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
 		ARG 1 index

--- a/data/net/minecraft/world/inventory/ResultContainer.mapping
+++ b/data/net/minecraft/world/inventory/ResultContainer.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/world/inventory/ResultContainer
 		COMMENT Removes a stack from the given slot and returns it.
 		ARG 1 index
 	METHOD setChanged ()V
-		COMMENT For tile entities, ensures the chunk containing the tile entity is saved to disk later - the game won't think it hasn't changed and skip it.
+		COMMENT For block entities, ensures the chunk containing the block entity is saved to disk later - the game won't think it hasn't changed and skip it.
 	METHOD setItem (ILnet/minecraft/world/item/ItemStack;)V
 		COMMENT Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
 		ARG 1 index

--- a/data/net/minecraft/world/item/DyeItem.mapping
+++ b/data/net/minecraft/world/item/DyeItem.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/world/item/DyeItem
 	METHOD byColor (Lnet/minecraft/world/item/DyeColor;)Lnet/minecraft/world/item/DyeItem;
 		ARG 0 color
 	METHOD interactLivingEntity (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/InteractionResult;
-		COMMENT Try interacting with givein entity. Return {@code InteractionResult.PASS} if nothing should happen.
+		COMMENT Try interacting with given entity. Return {@code InteractionResult.PASS} if nothing should happen.
 		ARG 1 stack
 		ARG 2 player
 		ARG 3 target

--- a/data/net/minecraft/world/item/DyeItem.mapping
+++ b/data/net/minecraft/world/item/DyeItem.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/world/item/DyeItem
 	METHOD byColor (Lnet/minecraft/world/item/DyeColor;)Lnet/minecraft/world/item/DyeItem;
 		ARG 0 color
 	METHOD interactLivingEntity (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/InteractionResult;
-		COMMENT Returns {@code true} if the item can be used on the given entity, e.g. shears on sheep.
+		COMMENT Try interacting with givein entity. Return {@code InteractionResult.PASS} if nothing should happen.
 		ARG 1 stack
 		ARG 2 player
 		ARG 3 target

--- a/data/net/minecraft/world/item/Item.mapping
+++ b/data/net/minecraft/world/item/Item.mapping
@@ -79,7 +79,7 @@ CLASS net/minecraft/world/item/Item
 		ARG 2 target
 		ARG 3 attacker
 	METHOD interactLivingEntity (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/InteractionResult;
-		COMMENT Returns {@code true} if the item can be used on the given entity, e.g. shears on sheep.
+		COMMENT Try interacting with givein entity. Return {@code InteractionResult.PASS} if nothing should happen.
 		ARG 1 stack
 		ARG 2 player
 		ARG 3 interactionTarget

--- a/data/net/minecraft/world/item/Item.mapping
+++ b/data/net/minecraft/world/item/Item.mapping
@@ -79,7 +79,7 @@ CLASS net/minecraft/world/item/Item
 		ARG 2 target
 		ARG 3 attacker
 	METHOD interactLivingEntity (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/InteractionResult;
-		COMMENT Try interacting with givein entity. Return {@code InteractionResult.PASS} if nothing should happen.
+		COMMENT Try interacting with given entity. Return {@code InteractionResult.PASS} if nothing should happen.
 		ARG 1 stack
 		ARG 2 player
 		ARG 3 interactionTarget

--- a/data/net/minecraft/world/item/NameTagItem.mapping
+++ b/data/net/minecraft/world/item/NameTagItem.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/item/NameTagItem
 	METHOD interactLivingEntity (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/InteractionResult;
-		COMMENT Returns {@code true} if the item can be used on the given entity, e.g. shears on sheep.
+		COMMENT Try interacting with givein entity. Return {@code InteractionResult.PASS} if nothing should happen.
 		ARG 1 stack
 		ARG 2 player
 		ARG 3 target

--- a/data/net/minecraft/world/item/NameTagItem.mapping
+++ b/data/net/minecraft/world/item/NameTagItem.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/item/NameTagItem
 	METHOD interactLivingEntity (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/InteractionResult;
-		COMMENT Try interacting with givein entity. Return {@code InteractionResult.PASS} if nothing should happen.
+		COMMENT Try interacting with given entity. Return {@code InteractionResult.PASS} if nothing should happen.
 		ARG 1 stack
 		ARG 2 player
 		ARG 3 target

--- a/data/net/minecraft/world/item/SaddleItem.mapping
+++ b/data/net/minecraft/world/item/SaddleItem.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/item/SaddleItem
 	METHOD interactLivingEntity (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/InteractionResult;
-		COMMENT Try interacting with givein entity. Return {@code InteractionResult.PASS} if nothing should happen.
+		COMMENT Try interacting with given entity. Return {@code InteractionResult.PASS} if nothing should happen.
 		ARG 1 stack
 		ARG 2 player
 		ARG 3 target

--- a/data/net/minecraft/world/item/SaddleItem.mapping
+++ b/data/net/minecraft/world/item/SaddleItem.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/world/item/SaddleItem
 	METHOD interactLivingEntity (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/InteractionResult;
-		COMMENT Returns {@code true} if the item can be used on the given entity, e.g. shears on sheep.
+		COMMENT Try interacting with givein entity. Return {@code InteractionResult.PASS} if nothing should happen.
 		ARG 1 stack
 		ARG 2 player
 		ARG 3 target

--- a/data/net/minecraft/world/level/block/state/BlockBehaviour.mapping
+++ b/data/net/minecraft/world/level/block/state/BlockBehaviour.mapping
@@ -177,7 +177,7 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 3 pos
 		ARG 4 random
 	METHOD triggerEvent (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;II)Z
-		COMMENT Called on server when {@link net.minecraft.world.level.Level#blockEvent} is called. If server returns true, then also called on the client. On the Server, this may perform additional changes to the world, like pistons replacing the block with an extended base. On the client, the update may involve replacing tile entities or effects such as sounds or particles
+		COMMENT Called on server when {@link net.minecraft.world.level.Level#blockEvent} is called. If server returns true, then also called on the client. On the Server, this may perform additional changes to the world, like pistons replacing the block with an extended base. On the client, the update may involve replacing block entities or effects such as sounds or particles
 		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#triggerEvent} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level


### PR DESCRIPTION
This PR changes all `TileEntity` to `BlockEntity`, for both javadoc and parameter names
and updates javadoc of `Item#interactLivingEntity` so that it better matches with class changes
I have removed parameter names of `{Server, Local}Player#openTextEdit` because these were still `TileEntity`, and was shadowed by `Player#openTextEdit` with correct parameter name.