### PR TITLE
Update NbtToSnbt.mapping

### DIFF
--- a/data/net/minecraft/data/structures/NbtToSnbt.mapping
+++ b/data/net/minecraft/data/structures/NbtToSnbt.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/data/structures/NbtToSnbt
 		ARG 1 generator
 	METHOD convertStructure (Lnet/minecraft/data/CachedOutput;Ljava/nio/file/Path;Ljava/lang/String;Ljava/nio/file/Path;)Ljava/nio/file/Path;
 		ARG 0 output
-		ARG 1 snbtPath
+		ARG 1 nbtPath
 		ARG 2 name
 		ARG 3 directoryPath
 	METHOD getName ()Ljava/lang/String;


### PR DESCRIPTION
We're iterating over all paths which were filtered with `path.toString().endsWith(".nbt")`, these paths are provided for the changed argument. These are nbt files and not the output snbt file. Because of this, I think this needs to be `nbtPath` instead of `snbtPath`.