### PR TITLE
[1.19] Remove javadoc for ServerPlayer#drop

### DIFF
--- a/data/net/minecraft/server/level/ServerPlayer.mapping
+++ b/data/net/minecraft/server/level/ServerPlayer.mapping
@@ -62,7 +62,6 @@ CLASS net/minecraft/server/level/ServerPlayer
 	METHOD doCloseContainer ()V
 		COMMENT Closes the container the player currently has open.
 	METHOD drop (Lnet/minecraft/world/item/ItemStack;ZZ)Lnet/minecraft/world/entity/item/ItemEntity;
-		COMMENT Creates and drops the provided item. Depending on the dropAround, it will drop teh item around the player, instead of dropping the item from where the player is pointing at. Likewise, if traceItem is true, the dropped item entity will have the thrower set as the player.
 		ARG 1 droppedItem
 		ARG 2 dropAround
 		ARG 3 traceItem


### PR DESCRIPTION
This PR fixes #179 by removing the javadoc for `ServerPlayer#drop`. The parent of this method, `Player#drop`, already has a javadoc with the same contents.