### PR TITLE
[1.18] Fix param names of VineBlock#isAcceptableNeighbor

### DIFF
--- a/data/net/minecraft/world/level/block/VineBlock.mapping
+++ b/data/net/minecraft/world/level/block/VineBlock.mapping
@@ -42,8 +42,8 @@ CLASS net/minecraft/world/level/block/VineBlock
 		ARG 1 state
 	METHOD isAcceptableNeighbour (Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;)Z
 		ARG 0 blockReader
-		ARG 1 level
-		ARG 2 neighborPos
+		ARG 1 neighborPos
+		ARG 2 attachedFace
 	METHOD lambda$static$0 (Ljava/util/Map$Entry;)Z
 		ARG 0 entry
 	METHOD mirror (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/Mirror;)Lnet/minecraft/world/level/block/state/BlockState;


### PR DESCRIPTION
This PR fixes #182 by fixing the parameter names of `VineBlock#isAcceptableNeighbor`, removing the `level` parameter, shifting the `neighborPos` name to the `BlockPos` parameater, and naming the remaining `Direction` parameter as `attachedFace`.

This is the 1.18 version of #186.