### PR TITLE
redstone signal javadocs and related refactors (1.20 edition)

### DIFF
--- a/data/net/minecraft/world/level/Level.mapping
+++ b/data/net/minecraft/world/level/Level.mapping
@@ -175,7 +175,7 @@ CLASS net/minecraft/world/level/Level
 		ARG 4 output
 		ARG 5 maxResults
 	METHOD getEntity (I)Lnet/minecraft/world/entity/Entity;
-		COMMENT Returns the Entity with the given ID, or null if it doesn't exist in this World.
+		COMMENT Returns the Entity with the given ID, or null if it doesn't exist in this Level.
 		ARG 1 id
 	METHOD getFluidState (Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/material/FluidState;
 		ARG 1 pos
@@ -221,7 +221,7 @@ CLASS net/minecraft/world/level/Level
 		COMMENT Returns {@code true} if the current rain strength is greater than 0.2
 	METHOD isRainingAt (Lnet/minecraft/core/BlockPos;)Z
 		COMMENT Check if precipitation is currently happening at a position
-		ARG 1 position
+		ARG 1 pos
 	METHOD isStateAtPosition (Lnet/minecraft/core/BlockPos;Ljava/util/function/Predicate;)Z
 		ARG 1 pos
 		ARG 2 state
@@ -347,7 +347,7 @@ CLASS net/minecraft/world/level/Level
 		ARG 1 packet
 	METHOD setBlock (Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Z
 		COMMENT Sets a block state into this world.Flags are as follows:
-		COMMENT 1 will cause a block update.
+		COMMENT 1 will notify neighboring blocks through {@link net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase#neighborChanged neighborChanged} updates.
 		COMMENT 2 will send the change to clients.
 		COMMENT 4 will prevent the block from being re-rendered.
 		COMMENT 8 will force any re-renders to run on the main thread instead

--- a/data/net/minecraft/world/level/SignalGetter.mapping
+++ b/data/net/minecraft/world/level/SignalGetter.mapping
@@ -1,19 +1,50 @@
 CLASS net/minecraft/world/level/SignalGetter
 	METHOD getBestNeighborSignal (Lnet/minecraft/core/BlockPos;)I
+		COMMENT Returns the highest redstone signal the given position receives from neighboring blocks.
 		ARG 1 pos
 	METHOD getControlInputSignal (Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;Z)I
+		COMMENT Returns the control signal emitted from the given position in the given direction.
+		COMMENT If {@code diodesOnly} is {@code true}, this method returns the direct signal emitted if
+		COMMENT and only if this position is occupied by a diode (i.e. a repeater or comparator).
+		COMMENT Otherwise, if this position is occupied by a redstone block, this method will return the
+		COMMENT redstone signal emitted by it. If not, this method will return the direct signal emitted
+		COMMENT from this position in the given direction.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone signal related methods are backwards, so this method
+		COMMENT checks for the signal emitted in the <i>opposite</i> direction of the one given.
 		ARG 1 pos
 		ARG 2 direction
+		ARG 3 diodesOnly
 	METHOD getDirectSignal (Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;)I
+		COMMENT Returns the direct redstone signal emitted from the given position in the given direction.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone signal related methods are backwards, so this method
+		COMMENT checks for the signal emitted in the <i>opposite</i> direction of the one given.
 		ARG 1 pos
 		ARG 2 direction
 	METHOD getDirectSignalTo (Lnet/minecraft/core/BlockPos;)I
+		COMMENT Returns the direct redstone signal the given position receives from neighboring blocks.
 		ARG 1 pos
 	METHOD getSignal (Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;)I
+		COMMENT Returns the redstone signal emitted from the given position in the given direction.
+		COMMENT This is the highest value between the signal emitted by the block itself, and the direct signal
+		COMMENT received from neighboring blocks if the block is a redstone conductor.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone signal related methods are backwards, so this method
+		COMMENT checks for the signal emitted in the <i>opposite</i> direction of the one given.
 		ARG 1 pos
 		ARG 2 direction
 	METHOD hasNeighborSignal (Lnet/minecraft/core/BlockPos;)Z
+		COMMENT Returns whether the given position receives any redstone signal from neighboring blocks.
 		ARG 1 pos
 	METHOD hasSignal (Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;)Z
+		COMMENT Returns whether a redstone signal is emitted from the given position in the given direction.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone signal related methods are backwards, so this method
+		COMMENT checks for the signal emitted in the <i>opposite</i> direction of the one given.
 		ARG 1 pos
 		ARG 2 direction

--- a/data/net/minecraft/world/level/SignalGetter.mapping
+++ b/data/net/minecraft/world/level/SignalGetter.mapping
@@ -6,9 +6,10 @@ CLASS net/minecraft/world/level/SignalGetter
 		COMMENT Returns the control signal emitted from the given position in the given direction.
 		COMMENT If {@code diodesOnly} is {@code true}, this method returns the direct signal emitted if
 		COMMENT and only if this position is occupied by a diode (i.e. a repeater or comparator).
-		COMMENT Otherwise, if this position is occupied by a redstone block, this method will return the
-		COMMENT redstone signal emitted by it. If not, this method will return the direct signal emitted
-		COMMENT from this position in the given direction.
+		COMMENT Otherwise, if this position is occupied by a
+		COMMENT {@linkplain net.minecraft.world.level.block.Blocks#REDSTONE_BLOCK redstone block},
+		COMMENT this method will return the redstone signal emitted by it. If not, this method will
+		COMMENT return the direct signal emitted from this position in the given direction.
 		COMMENT
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone signal related methods are backwards, so this method

--- a/data/net/minecraft/world/level/block/DiodeBlock.mapping
+++ b/data/net/minecraft/world/level/block/DiodeBlock.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/world/level/block/DiodeBlock
 		ARG 2 pos
 		ARG 3 state
 	METHOD getAlternateSignal (Lnet/minecraft/world/level/SignalGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)I
-		ARG 1 signalGetter
+		ARG 1 level
 		ARG 2 pos
 		ARG 3 state
 	METHOD getDelay (Lnet/minecraft/world/level/block/state/BlockState;)I

--- a/data/net/minecraft/world/level/block/state/BlockBehaviour.mapping
+++ b/data/net/minecraft/world/level/block/state/BlockBehaviour.mapping
@@ -26,13 +26,15 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 3 pos
 		ARG 4 entity
 	METHOD getAnalogOutputSignal (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)I
+		COMMENT Returns the analog signal this block emits. This is the signal a comparator can read from it.
+		COMMENT
 		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getAnalogOutputSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos
 	METHOD getBlockSupportShape (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/phys/shapes/VoxelShape;
 		ARG 1 state
-		ARG 2 reader
+		ARG 2 level
 		ARG 3 pos
 	METHOD getCollisionShape (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/phys/shapes/CollisionContext;)Lnet/minecraft/world/phys/shapes/VoxelShape;
 		ARG 1 state
@@ -47,6 +49,12 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 3 level
 		ARG 4 pos
 	METHOD getDirectSignal (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;)I
+		COMMENT Returns the direct signal this block emits in the given direction.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone signal related methods are backwards, so this method
+		COMMENT checks for the signal emitted in the <i>opposite</i> direction of the one given.
+		COMMENT
 		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getDirectSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
@@ -91,6 +99,12 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 3 pos
 		ARG 4 context
 	METHOD getSignal (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;)I
+		COMMENT Returns the signal this block emits in the given direction.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone signal related methods are backwards, so this method
+		COMMENT checks for the signal emitted in the <i>opposite</i> direction of the one given.
+		COMMENT
 		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
@@ -118,7 +132,8 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 3 pos
 		ARG 4 type
 	METHOD isSignalSource (Lnet/minecraft/world/level/block/state/BlockState;)Z
-		COMMENT Can this block provide power. Only wire currently seems to have this change based on its state.
+		COMMENT Returns whether this block is capable of emitting redstone signals.
+		COMMENT
 		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#isSignalSource} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 	METHOD mirror (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/Mirror;)Lnet/minecraft/world/level/block/state/BlockState;
@@ -130,15 +145,15 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos
-		ARG 4 block
-		ARG 5 fromPos
-		ARG 6 isMoving
+		ARG 4 neighborBlock
+		ARG 5 neighborPos
+		ARG 6 movedByPiston
 	METHOD onPlace (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Z)V
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos
 		ARG 4 oldState
-		ARG 5 isMoving
+		ARG 5 movedByPiston
 	METHOD onProjectileHit (Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/phys/BlockHitResult;Lnet/minecraft/world/entity/projectile/Projectile;)V
 		ARG 1 level
 		ARG 2 state
@@ -149,7 +164,7 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 2 level
 		ARG 3 pos
 		ARG 4 newState
-		ARG 5 isMoving
+		ARG 5 movedByPiston
 	METHOD randomTick (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/core/BlockPos;Lnet/minecraft/util/RandomSource;)V
 		COMMENT Performs a random tick on a block.
 		ARG 1 state
@@ -163,7 +178,7 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 2 rotation
 	METHOD skipRendering (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/Direction;)Z
 		ARG 1 state
-		ARG 2 adjacentBlockState
+		ARG 2 adjacentState
 		ARG 3 direction
 	METHOD spawnAfterBreak (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;Z)V
 		COMMENT Perform side-effects from block dropping, such as creating silverfish
@@ -186,8 +201,14 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 4 id
 		ARG 5 param
 	METHOD updateIndirectNeighbourShapes (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;II)V
-		COMMENT Performs updates on diagonal neighbors of the target position and passes in the flags.
-		COMMENT The flags are equivalent to {@link net.minecraft.world.level.Level#setBlock}.
+		COMMENT Updates the shapes of indirect neighbors of this block. This method is analogous to
+		COMMENT {@link net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase#updateNeighbourShapes}
+		COMMENT but where that method affects the 6 direct neighbors of this block, this method affects
+		COMMENT the indirect neighbors, if any.
+		COMMENT
+		COMMENT <p>
+		COMMENT Currently the only implementation of this method is {@link net.minecraft.world.level.block.RedStoneWireBlock#updateIndirectNeighbourShapes}
+		COMMENT where it is used to validate diagonal connections of redstone wire blocks.
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos
@@ -201,7 +222,7 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 2 direction
 		ARG 3 neighborState
 		ARG 4 level
-		ARG 5 currentPos
+		ARG 5 pos
 		ARG 6 neighborPos
 	METHOD use (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/phys/BlockHitResult;)Lnet/minecraft/world/InteractionResult;
 		ARG 1 state
@@ -440,14 +461,14 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		METHOD neighborChanged (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Block;Lnet/minecraft/core/BlockPos;Z)V
 			ARG 1 level
 			ARG 2 pos
-			ARG 3 block
-			ARG 4 fromPos
-			ARG 5 isMoving
+			ARG 3 neighborBlock
+			ARG 4 neighborPos
+			ARG 5 movedByPiston
 		METHOD onPlace (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Z)V
 			ARG 1 level
 			ARG 2 pos
 			ARG 3 oldState
-			ARG 4 isMoving
+			ARG 4 movedByPiston
 		METHOD onProjectileHit (Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/phys/BlockHitResult;Lnet/minecraft/world/entity/projectile/Projectile;)V
 			ARG 1 level
 			ARG 2 state
@@ -457,7 +478,7 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 			ARG 1 level
 			ARG 2 pos
 			ARG 3 newState
-			ARG 4 isMoving
+			ARG 4 movedByPiston
 		METHOD propagatesSkylightDown (Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z
 			ARG 1 level
 			ARG 2 pos
@@ -486,7 +507,6 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 			ARG 3 id
 			ARG 4 param
 		METHOD updateIndirectNeighbourShapes (Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;I)V
-			COMMENT Performs validations on the block state and possibly neighboring blocks to validate whether the incoming state is valid to stay in the world. Currently used only by redstone wire to update itself if neighboring blocks have changed and to possibly break itself.
 			ARG 1 level
 			ARG 2 pos
 			ARG 3 flags
@@ -498,18 +518,18 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		METHOD updateNeighbourShapes (Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;I)V
 			ARG 1 level
 			ARG 2 pos
-			ARG 3 flag
+			ARG 3 flags
 		METHOD updateNeighbourShapes (Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;II)V
 			ARG 1 level
 			ARG 2 pos
-			ARG 3 flag
+			ARG 3 flags
 			ARG 4 recursionLeft
 		METHOD updateShape (Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;
 			ARG 1 direction
-			ARG 2 queried
+			ARG 2 neighborState
 			ARG 3 level
-			ARG 4 currentPos
-			ARG 5 offsetPos
+			ARG 4 pos
+			ARG 5 neighborPos
 		METHOD use (Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/phys/BlockHitResult;)Lnet/minecraft/world/InteractionResult;
 			ARG 1 level
 			ARG 2 player


### PR DESCRIPTION
some of the changes from #200 got lost in the update to 1.20, and on top of that, some of the code that used to be in `Level` got moved into its own interface, `SignalGetter`, so I ported the javadocs over to that