### PR TITLE
Fix name collision in RegistrySetBuilder

### DIFF
--- a/data/net/minecraft/core/RegistrySetBuilder.mapping
+++ b/data/net/minecraft/core/RegistrySetBuilder.mapping
@@ -14,7 +14,7 @@ CLASS net/minecraft/core/RegistrySetBuilder
 	METHOD createState (Lnet/minecraft/core/RegistryAccess;)Lnet/minecraft/core/RegistrySetBuilder$BuildState;
 		ARG 1 registryAccess
 	METHOD wrapContextLookup (Lnet/minecraft/core/HolderLookup$RegistryLookup;)Lnet/minecraft/core/HolderGetter;
-		ARG 0 owner
+		ARG 0 lookupWrapper
 	CLASS BuildState
 		METHOD addOwner (Lnet/minecraft/core/HolderOwner;)V
 			ARG 1 owner


### PR DESCRIPTION
The parameter cannot be named `owner` because it collides with a visible field named `owner` inside `EmptyTagLookup`.