### PR TITLE
The rest of the world.level.storage.loot package

### DIFF
--- a/data/net/minecraft/world/level/storage/loot/IntRange.mapping
+++ b/data/net/minecraft/world/level/storage/loot/IntRange.mapping
@@ -35,3 +35,12 @@ CLASS net/minecraft/world/level/storage/loot/IntRange
 		METHOD apply (Lnet/minecraft/world/level/storage/loot/LootContext;I)I
 			ARG 1 lootContext
 			ARG 2 value
+	CLASS Serializer
+		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/world/level/storage/loot/IntRange;
+			ARG 1 elementJson
+			ARG 2 type
+			ARG 3 context
+		METHOD serialize (Lnet/minecraft/world/level/storage/loot/IntRange;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+			ARG 1 intRange
+			ARG 2 type
+			ARG 3 context

--- a/data/net/minecraft/world/level/storage/loot/IntRange.mapping
+++ b/data/net/minecraft/world/level/storage/loot/IntRange.mapping
@@ -37,10 +37,10 @@ CLASS net/minecraft/world/level/storage/loot/IntRange
 			ARG 2 value
 	CLASS Serializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/world/level/storage/loot/IntRange;
-			ARG 1 elementJson
-			ARG 2 type
+			ARG 1 json
+			ARG 2 typeOfT
 			ARG 3 context
 		METHOD serialize (Lnet/minecraft/world/level/storage/loot/IntRange;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
-			ARG 1 intRange
-			ARG 2 type
+			ARG 1 src
+			ARG 2 typeOfSrc
 			ARG 3 context

--- a/data/net/minecraft/world/level/storage/loot/LootDataManager.mapping
+++ b/data/net/minecraft/world/level/storage/loot/LootDataManager.mapping
@@ -25,6 +25,8 @@ CLASS net/minecraft/world/level/storage/loot/LootDataManager
 		ARG 1 errorMessage
 	METHOD lambda$reload$0 (Lnet/minecraft/server/packs/resources/ResourceManager;Ljava/util/concurrent/Executor;Ljava/util/Map;Lnet/minecraft/world/level/storage/loot/LootDataType;)Ljava/util/concurrent/CompletableFuture;
 		ARG 3 lootDataType
+	METHOD lambda$reload$1 (I)[Ljava/util/concurrent/CompletableFuture;
+		ARG 1 size
 	METHOD lambda$reload$2 (Ljava/util/Map;Ljava/lang/Void;)V
 		ARG 2 ignored
 	METHOD lambda$scheduleElementParse$3 (Ljava/util/Map;Lnet/minecraft/resources/ResourceLocation;Ljava/lang/Object;)V

--- a/data/net/minecraft/world/level/storage/loot/LootDataManager.mapping
+++ b/data/net/minecraft/world/level/storage/loot/LootDataManager.mapping
@@ -26,7 +26,7 @@ CLASS net/minecraft/world/level/storage/loot/LootDataManager
 	METHOD lambda$reload$0 (Lnet/minecraft/server/packs/resources/ResourceManager;Ljava/util/concurrent/Executor;Ljava/util/Map;Lnet/minecraft/world/level/storage/loot/LootDataType;)Ljava/util/concurrent/CompletableFuture;
 		ARG 3 lootDataType
 	METHOD lambda$reload$1 (I)[Ljava/util/concurrent/CompletableFuture;
-		ARG 1 size
+		ARG 0 size
 	METHOD lambda$reload$2 (Ljava/util/Map;Ljava/lang/Void;)V
 		ARG 2 ignored
 	METHOD lambda$scheduleElementParse$3 (Ljava/util/Map;Lnet/minecraft/resources/ResourceLocation;Ljava/lang/Object;)V

--- a/data/net/minecraft/world/level/storage/loot/LootDataManager.mapping
+++ b/data/net/minecraft/world/level/storage/loot/LootDataManager.mapping
@@ -1,17 +1,42 @@
 CLASS net/minecraft/world/level/storage/loot/LootDataManager
+	METHOD apply (Ljava/util/Map;)V
+		ARG 1 collectedElements
 	METHOD castAndValidate (Lnet/minecraft/world/level/storage/loot/ValidationContext;Lnet/minecraft/world/level/storage/loot/LootDataId;Ljava/lang/Object;)V
 		ARG 0 context
 		ARG 1 id
+		ARG 2 element
 	METHOD createComposite ([Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;
 		ARG 0 functions
 	METHOD createComposite ([Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition;)Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition;
 		ARG 0 terms
 	METHOD getKeys (Lnet/minecraft/world/level/storage/loot/LootDataType;)Ljava/util/Collection;
 		ARG 1 type
+	METHOD lambda$apply$6 (Lcom/google/common/collect/ImmutableMap$Builder;Lnet/minecraft/world/level/storage/loot/LootDataType;Lcom/google/common/collect/ImmutableMultimap$Builder;Lnet/minecraft/resources/ResourceLocation;Ljava/lang/Object;)V
+		ARG 3 elementName
+		ARG 4 element
+	METHOD lambda$apply$7 (Lcom/google/common/collect/ImmutableMap$Builder;Lcom/google/common/collect/ImmutableMultimap$Builder;Lnet/minecraft/world/level/storage/loot/LootDataType;Ljava/util/Map;)V
+		ARG 2 lootDataType
+		ARG 3 elements
+	METHOD lambda$apply$8 (Lnet/minecraft/world/level/storage/loot/ValidationContext;Lnet/minecraft/world/level/storage/loot/LootDataId;Ljava/lang/Object;)V
+		ARG 1 id
+		ARG 2 element
+	METHOD lambda$apply$9 (Ljava/lang/String;Ljava/lang/String;)V
+		ARG 0 errorOwner
+		ARG 1 errorMessage
+	METHOD lambda$reload$0 (Lnet/minecraft/server/packs/resources/ResourceManager;Ljava/util/concurrent/Executor;Ljava/util/Map;Lnet/minecraft/world/level/storage/loot/LootDataType;)Ljava/util/concurrent/CompletableFuture;
+		ARG 3 lootDataType
+	METHOD lambda$reload$2 (Ljava/util/Map;Ljava/lang/Void;)V
+		ARG 2 ignored
+	METHOD lambda$scheduleElementParse$3 (Ljava/util/Map;Lnet/minecraft/resources/ResourceLocation;Ljava/lang/Object;)V
+		ARG 2 element
+	METHOD lambda$scheduleElementParse$4 (Lnet/minecraft/world/level/storage/loot/LootDataType;Ljava/util/Map;Lnet/minecraft/resources/ResourceLocation;Lcom/google/gson/JsonElement;)V
+		ARG 2 elementName
+		ARG 3 elementJson
 	METHOD scheduleElementParse (Lnet/minecraft/world/level/storage/loot/LootDataType;Lnet/minecraft/server/packs/resources/ResourceManager;Ljava/util/concurrent/Executor;Ljava/util/Map;)Ljava/util/concurrent/CompletableFuture;
 		ARG 0 lootDataType
 		ARG 1 resourceManager
 		ARG 2 backgroundExecutor
+		ARG 3 elementCollector
 	CLASS FunctionSequence
 		METHOD <init> ([Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V
 			ARG 1 functions

--- a/data/net/minecraft/world/level/storage/loot/LootDataType.mapping
+++ b/data/net/minecraft/world/level/storage/loot/LootDataType.mapping
@@ -4,13 +4,32 @@ CLASS net/minecraft/world/level/storage/loot/LootDataType
 		ARG 2 topDeserializerGetter
 		ARG 3 directory
 		ARG 4 validator
+	METHOD createSingleDeserialiser (Ljava/lang/Class;)Ljava/util/function/BiFunction;
+		ARG 0 valueType
+	METHOD createSingleOrMultipleDeserialiser (Ljava/lang/Class;Ljava/util/function/Function;)Ljava/util/function/BiFunction;
+		ARG 0 valueType
+		ARG 1 combiner
 	METHOD deserialize (Lnet/minecraft/resources/ResourceLocation;Lcom/google/gson/JsonElement;)Ljava/util/Optional;
 		ARG 1 location
 		ARG 2 json
+	METHOD lambda$createSingleDeserialiser$0 (Lcom/google/gson/Gson;Ljava/lang/Class;Ljava/lang/String;Lnet/minecraft/resources/ResourceLocation;Lcom/google/gson/JsonElement;)Ljava/util/Optional;
+		ARG 3 elementName
+		ARG 4 elementJson
+	METHOD lambda$createSingleDeserialiser$1 (Ljava/lang/Class;Lcom/google/gson/Gson;Ljava/lang/String;)Ljava/util/function/BiFunction;
+		ARG 1 gson
+		ARG 2 directory
+	METHOD lambda$createSingleOrMultipleDeserialiser$2 (Lcom/google/gson/Gson;Ljava/lang/Class;Ljava/util/function/Function;Ljava/lang/Class;Ljava/lang/String;Lnet/minecraft/resources/ResourceLocation;Lcom/google/gson/JsonElement;)Ljava/util/Optional;
+		ARG 5 elementName
+		ARG 6 elementJson
+	METHOD lambda$createSingleOrMultipleDeserialiser$3 (Ljava/lang/Class;Ljava/util/function/Function;Ljava/lang/Class;Lcom/google/gson/Gson;Ljava/lang/String;)Ljava/util/function/BiFunction;
+		ARG 0 gson
+		ARG 1 directory
 	METHOD runValidation (Lnet/minecraft/world/level/storage/loot/ValidationContext;Lnet/minecraft/world/level/storage/loot/LootDataId;Ljava/lang/Object;)V
 		ARG 1 context
 		ARG 2 id
+		ARG 3 element
 	CLASS Validator
 		METHOD run (Lnet/minecraft/world/level/storage/loot/ValidationContext;Lnet/minecraft/world/level/storage/loot/LootDataId;Ljava/lang/Object;)V
 			ARG 1 context
 			ARG 2 id
+			ARG 3 element

--- a/data/net/minecraft/world/level/storage/loot/LootPool.mapping
+++ b/data/net/minecraft/world/level/storage/loot/LootPool.mapping
@@ -28,10 +28,10 @@ CLASS net/minecraft/world/level/storage/loot/LootPool
 			ARG 1 rolls
 	CLASS Serializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/world/level/storage/loot/LootPool;
-			ARG 1 elementJson
-			ARG 2 type
+			ARG 1 json
+			ARG 2 typeOfT
 			ARG 3 context
 		METHOD serialize (Lnet/minecraft/world/level/storage/loot/LootPool;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
-			ARG 1 lootPool
-			ARG 2 type
+			ARG 1 src
+			ARG 2 typeOfSrc
 			ARG 3 context

--- a/data/net/minecraft/world/level/storage/loot/LootPool.mapping
+++ b/data/net/minecraft/world/level/storage/loot/LootPool.mapping
@@ -14,6 +14,8 @@ CLASS net/minecraft/world/level/storage/loot/LootPool
 		COMMENT Then the random items are generated based on the {@link LootPoolEntry LootPoolEntries} in this pool according to the rolls and bonusRolls, applying any loot functions.
 		ARG 1 stackConsumer
 		ARG 2 lootContext
+	METHOD lambda$addRandomItem$0 (Lnet/minecraft/world/level/storage/loot/LootContext;Ljava/util/List;Lorg/apache/commons/lang3/mutable/MutableInt;Lnet/minecraft/world/level/storage/loot/entries/LootPoolEntry;)V
+		ARG 3 poolEntry
 	METHOD validate (Lnet/minecraft/world/level/storage/loot/ValidationContext;)V
 		COMMENT Validate this LootPool according to the given context.
 		ARG 1 context

--- a/data/net/minecraft/world/level/storage/loot/LootPool.mapping
+++ b/data/net/minecraft/world/level/storage/loot/LootPool.mapping
@@ -24,3 +24,12 @@ CLASS net/minecraft/world/level/storage/loot/LootPool
 			ARG 1 bonusRolls
 		METHOD setRolls (Lnet/minecraft/world/level/storage/loot/providers/number/NumberProvider;)Lnet/minecraft/world/level/storage/loot/LootPool$Builder;
 			ARG 1 rolls
+	CLASS Serializer
+		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/world/level/storage/loot/LootPool;
+			ARG 1 elementJson
+			ARG 2 type
+			ARG 3 context
+		METHOD serialize (Lnet/minecraft/world/level/storage/loot/LootPool;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+			ARG 1 lootPool
+			ARG 2 type
+			ARG 3 context

--- a/data/net/minecraft/world/level/storage/loot/LootTable.mapping
+++ b/data/net/minecraft/world/level/storage/loot/LootTable.mapping
@@ -42,6 +42,8 @@ CLASS net/minecraft/world/level/storage/loot/LootTable
 	METHOD getRandomItemsRaw (Lnet/minecraft/world/level/storage/loot/LootParams;Ljava/util/function/Consumer;)V
 		ARG 1 params
 		ARG 2 output
+	METHOD lambda$createStackSplitter$0 (Lnet/minecraft/server/level/ServerLevel;Ljava/util/function/Consumer;Lnet/minecraft/world/item/ItemStack;)V
+		ARG 2 itemStack
 	METHOD shuffleAndSplitItems (Lit/unimi/dsi/fastutil/objects/ObjectArrayList;ILnet/minecraft/util/RandomSource;)V
 		COMMENT Shuffles items by changing their order and splitting stacks
 		ARG 1 stacks

--- a/data/net/minecraft/world/level/storage/loot/entries/AlternativesEntry.mapping
+++ b/data/net/minecraft/world/level/storage/loot/entries/AlternativesEntry.mapping
@@ -1,10 +1,15 @@
 CLASS net/minecraft/world/level/storage/loot/entries/AlternativesEntry
 	COMMENT A composite loot pool entry container that expands all its children in order until one of them succeeds.
 	COMMENT This container succeeds if one of its children succeeds.
+	METHOD alternatives (Ljava/util/Collection;Ljava/util/function/Function;)Lnet/minecraft/world/level/storage/loot/entries/AlternativesEntry$Builder;
+		ARG 0 childrenSources
+		ARG 1 toChildrenFunction
 	METHOD alternatives ([Lnet/minecraft/world/level/storage/loot/entries/LootPoolEntryContainer$Builder;)Lnet/minecraft/world/level/storage/loot/entries/AlternativesEntry$Builder;
 		ARG 0 children
 	METHOD compose ([Lnet/minecraft/world/level/storage/loot/entries/ComposableEntryContainer;)Lnet/minecraft/world/level/storage/loot/entries/ComposableEntryContainer;
 		ARG 1 entries
+	METHOD lambda$alternatives$1 (I)[Lnet/minecraft/world/level/storage/loot/entries/LootPoolEntryContainer$Builder;
+		ARG 0 size
 	CLASS Builder
 		METHOD <init> ([Lnet/minecraft/world/level/storage/loot/entries/LootPoolEntryContainer$Builder;)V
 			ARG 1 children

--- a/data/net/minecraft/world/level/storage/loot/entries/LootTableReference.mapping
+++ b/data/net/minecraft/world/level/storage/loot/entries/LootTableReference.mapping
@@ -6,6 +6,8 @@ CLASS net/minecraft/world/level/storage/loot/entries/LootTableReference
 		ARG 3 quality
 		ARG 4 conditions
 		ARG 5 functions
+	METHOD lambda$validate$0 (Lnet/minecraft/world/level/storage/loot/ValidationContext;Lnet/minecraft/world/level/storage/loot/LootDataId;Lnet/minecraft/world/level/storage/loot/LootTable;)V
+		ARG 3 lootTable
 	METHOD lootTableReference (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/world/level/storage/loot/entries/LootPoolSingletonContainer$Builder;
 		ARG 0 table
 	CLASS Serializer

--- a/data/net/minecraft/world/level/storage/loot/entries/TagEntry.mapping
+++ b/data/net/minecraft/world/level/storage/loot/entries/TagEntry.mapping
@@ -13,6 +13,8 @@ CLASS net/minecraft/world/level/storage/loot/entries/TagEntry
 	METHOD expandTag (Lnet/minecraft/world/level/storage/loot/LootContext;Ljava/util/function/Consumer;)Z
 		ARG 1 context
 		ARG 2 generatorConsumer
+	METHOD lambda$createItemStack$0 (Ljava/util/function/Consumer;Lnet/minecraft/core/Holder;)V
+		ARG 1 item
 	METHOD tagContents (Lnet/minecraft/tags/TagKey;)Lnet/minecraft/world/level/storage/loot/entries/LootPoolSingletonContainer$Builder;
 		ARG 0 tag
 	CLASS Serializer


### PR DESCRIPTION
After https://github.com/ParchmentMC/Parchment/pull/236, #235 , and #234, the whole `net.minecraft.world.level.storage.loot` package should be mapped. Enigma won't show that cause it isn't great identifying what is missing.