### PR TITLE
Consistency for `RecordCodecBuilder$Instance`

### DIFF
--- a/data/net/minecraft/util/Brightness.mapping
+++ b/data/net/minecraft/util/Brightness.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/util/Brightness
 	METHOD lambda$static$0 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 in
+		ARG 0 instance
 	METHOD unpack (I)Lnet/minecraft/util/Brightness;
 		ARG 0 packedBrightness

--- a/data/net/minecraft/util/CubicSpline.mapping
+++ b/data/net/minecraft/util/CubicSpline.mapping
@@ -6,6 +6,8 @@ CLASS net/minecraft/util/CubicSpline
 		ARG 1 valueTransformer
 	METHOD constant (F)Lnet/minecraft/util/CubicSpline;
 		ARG 0 value
+	METHOD lambda$codec$1 (Lorg/apache/commons/lang3/mutable/MutableObject;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 1 instance
 	METHOD lambda$codec$4 (Lnet/minecraft/util/ToFloatFunction;Ljava/util/List;)Lnet/minecraft/util/CubicSpline$Multipoint;
 		ARG 0 coordinate
 	METHOD lambda$codec$5 (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;

--- a/data/net/minecraft/world/entity/ai/village/poi/PoiRecord.mapping
+++ b/data/net/minecraft/world/entity/ai/village/poi/PoiRecord.mapping
@@ -17,4 +17,4 @@ CLASS net/minecraft/world/entity/ai/village/poi/PoiRecord
 	METHOD lambda$codec$2 (Lnet/minecraft/world/entity/ai/village/poi/PoiRecord;)Ljava/lang/Integer;
 		ARG 0 getter
 	METHOD lambda$codec$3 (Ljava/lang/Runnable;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 1 codec
+		ARG 1 instance

--- a/data/net/minecraft/world/entity/ai/village/poi/PoiSection.mapping
+++ b/data/net/minecraft/world/entity/ai/village/poi/PoiSection.mapping
@@ -29,7 +29,7 @@ CLASS net/minecraft/world/entity/ai/village/poi/PoiSection
 	METHOD lambda$codec$1 (Lnet/minecraft/world/entity/ai/village/poi/PoiSection;)Ljava/util/List;
 		ARG 0 getter
 	METHOD lambda$codec$2 (Ljava/lang/Runnable;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 1 codec
+		ARG 1 instance
 	METHOD lambda$getRecords$4 (Ljava/util/function/Predicate;Ljava/util/Map$Entry;)Z
 		ARG 1 type
 	METHOD lambda$getRecords$5 (Ljava/util/Map$Entry;)Ljava/util/stream/Stream;

--- a/data/net/minecraft/world/entity/npc/VillagerData.mapping
+++ b/data/net/minecraft/world/entity/npc/VillagerData.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/world/entity/npc/VillagerData
 	METHOD getMinXpPerLevel (I)I
 		ARG 0 level
 	METHOD lambda$static$5 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codecInstance
+		ARG 0 instance
 	METHOD setLevel (I)Lnet/minecraft/world/entity/npc/VillagerData;
 		ARG 1 level
 	METHOD setProfession (Lnet/minecraft/world/entity/npc/VillagerProfession;)Lnet/minecraft/world/entity/npc/VillagerData;

--- a/data/net/minecraft/world/level/DataPackConfig.mapping
+++ b/data/net/minecraft/world/level/DataPackConfig.mapping
@@ -9,4 +9,4 @@ CLASS net/minecraft/world/level/DataPackConfig
 	METHOD lambda$static$1 (Lnet/minecraft/world/level/DataPackConfig;)Ljava/util/List;
 		ARG 0 getter
 	METHOD lambda$static$2 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codec
+		ARG 0 instance

--- a/data/net/minecraft/world/level/biome/AmbientParticleSettings.mapping
+++ b/data/net/minecraft/world/level/biome/AmbientParticleSettings.mapping
@@ -9,4 +9,4 @@ CLASS net/minecraft/world/level/biome/AmbientParticleSettings
 	METHOD lambda$static$1 (Lnet/minecraft/world/level/biome/AmbientParticleSettings;)Ljava/lang/Float;
 		ARG 0 settings
 	METHOD lambda$static$2 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codec
+		ARG 0 instance

--- a/data/net/minecraft/world/level/biome/Biome.mapping
+++ b/data/net/minecraft/world/level/biome/Biome.mapping
@@ -76,7 +76,7 @@ CLASS net/minecraft/world/level/biome/Biome
 		METHOD lambda$static$3 (Lnet/minecraft/world/level/biome/Biome$ClimateSettings;)Ljava/lang/Float;
 			ARG 0 settings
 		METHOD lambda$static$4 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-			ARG 0 codec
+			ARG 0 instance
 	CLASS TemperatureModifier
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 name

--- a/data/net/minecraft/world/level/biome/BiomeSpecialEffects.mapping
+++ b/data/net/minecraft/world/level/biome/BiomeSpecialEffects.mapping
@@ -21,7 +21,7 @@ CLASS net/minecraft/world/level/biome/BiomeSpecialEffects
 	METHOD lambda$static$11 (Lnet/minecraft/world/level/biome/BiomeSpecialEffects;)Ljava/util/Optional;
 		ARG 0 effects
 	METHOD lambda$static$12 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codec
+		ARG 0 instance
 	METHOD lambda$static$2 (Lnet/minecraft/world/level/biome/BiomeSpecialEffects;)Ljava/lang/Integer;
 		ARG 0 effects
 	METHOD lambda$static$3 (Lnet/minecraft/world/level/biome/BiomeSpecialEffects;)Ljava/lang/Integer;

--- a/data/net/minecraft/world/level/biome/CheckerboardColumnBiomeSource.mapping
+++ b/data/net/minecraft/world/level/biome/CheckerboardColumnBiomeSource.mapping
@@ -7,4 +7,4 @@ CLASS net/minecraft/world/level/biome/CheckerboardColumnBiomeSource
 	METHOD lambda$static$1 (Lnet/minecraft/world/level/biome/CheckerboardColumnBiomeSource;)Ljava/lang/Integer;
 		ARG 0 checker
 	METHOD lambda$static$2 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codec
+		ARG 0 instance

--- a/data/net/minecraft/world/level/biome/Climate.mapping
+++ b/data/net/minecraft/world/level/biome/Climate.mapping
@@ -158,4 +158,4 @@ CLASS net/minecraft/world/level/biome/Climate
 		METHOD lambda$static$6 (Lnet/minecraft/world/level/biome/Climate$ParameterPoint;)Ljava/lang/Long;
 			ARG 0 point
 		METHOD lambda$static$7 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-			ARG 0 codec
+			ARG 0 instance

--- a/data/net/minecraft/world/level/biome/MobSpawnSettings.mapping
+++ b/data/net/minecraft/world/level/biome/MobSpawnSettings.mapping
@@ -14,7 +14,7 @@ CLASS net/minecraft/world/level/biome/MobSpawnSettings
 	METHOD lambda$static$2 (Lnet/minecraft/world/level/biome/MobSpawnSettings;)Ljava/util/Map;
 		ARG 0 settings
 	METHOD lambda$static$3 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codec
+		ARG 0 instance
 	CLASS Builder
 		METHOD addMobCharge (Lnet/minecraft/world/entity/EntityType;DD)Lnet/minecraft/world/level/biome/MobSpawnSettings$Builder;
 			ARG 1 entityType

--- a/data/net/minecraft/world/level/gameevent/BlockPositionSource.mapping
+++ b/data/net/minecraft/world/level/gameevent/BlockPositionSource.mapping
@@ -4,4 +4,4 @@ CLASS net/minecraft/world/level/gameevent/BlockPositionSource
 	METHOD lambda$static$0 (Lnet/minecraft/world/level/gameevent/BlockPositionSource;)Lnet/minecraft/core/BlockPos;
 		ARG 0 positionSource
 	METHOD lambda$static$1 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codec
+		ARG 0 instance

--- a/data/net/minecraft/world/level/levelgen/DensityFunctions.mapping
+++ b/data/net/minecraft/world/level/levelgen/DensityFunctions.mapping
@@ -24,6 +24,10 @@ CLASS net/minecraft/world/level/levelgen/DensityFunctions
 		ARG 0 wrapped
 	METHOD interpolated (Lnet/minecraft/world/level/levelgen/DensityFunction;)Lnet/minecraft/world/level/levelgen/DensityFunction;
 		ARG 0 wrapped
+	METHOD lambda$doubleFunctionArgumentCodec$3 (Ljava/util/function/Function;Ljava/util/function/Function;Ljava/util/function/BiFunction;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 3 instance
+	METHOD lambda$static$0 (Lnet/minecraft/world/level/levelgen/DensityFunction;)Lcom/mojang/serialization/Codec;
+		ARG 0 type
 	METHOD lerp (Lnet/minecraft/world/level/levelgen/DensityFunction;DLnet/minecraft/world/level/levelgen/DensityFunction;)Lnet/minecraft/world/level/levelgen/DensityFunction;
 		ARG 0 deltaFunction
 		ARG 1 min
@@ -115,10 +119,10 @@ CLASS net/minecraft/world/level/levelgen/DensityFunctions
 		ARG 4 toValue
 	CLASS Clamp
 		METHOD lambda$static$0 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-			ARG 0 params
+			ARG 0 instance
 	CLASS Noise
 		METHOD lambda$static$0 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-			ARG 0 codec
+			ARG 0 instance
 	CLASS Mapped
 		METHOD create (Lnet/minecraft/world/level/levelgen/DensityFunctions$Mapped$Type;Lnet/minecraft/world/level/levelgen/DensityFunction;)Lnet/minecraft/world/level/levelgen/DensityFunctions$Mapped;
 			ARG 0 type
@@ -148,10 +152,10 @@ CLASS net/minecraft/world/level/levelgen/DensityFunctions
 			ARG 5 z
 	CLASS RangeChoice
 		METHOD lambda$static$0 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-			ARG 0 codec
+			ARG 0 instance
 	CLASS ShiftedNoise
 		METHOD lambda$static$0 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-			ARG 0 codec
+			ARG 0 instance
 	CLASS PureTransformer
 		METHOD transform (D)D
 			ARG 1 value
@@ -160,7 +164,7 @@ CLASS net/minecraft/world/level/levelgen/DensityFunctions
 			ARG 0 codec
 	CLASS WeirdScaledSampler
 		METHOD lambda$static$0 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-			ARG 0 codec
+			ARG 0 instance
 		CLASS RarityValueMapper
 			METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lit/unimi/dsi/fastutil/doubles/Double2DoubleFunction;D)V
 				ARG 3 name

--- a/data/net/minecraft/world/level/levelgen/FlatLevelSource.mapping
+++ b/data/net/minecraft/world/level/levelgen/FlatLevelSource.mapping
@@ -4,4 +4,4 @@ CLASS net/minecraft/world/level/levelgen/FlatLevelSource
 	METHOD lambda$getBaseColumn$3 (Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/block/state/BlockState;
 		ARG 0 state
 	METHOD lambda$static$0 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codec
+		ARG 0 instance

--- a/data/net/minecraft/world/level/levelgen/GeodeBlockSettings.mapping
+++ b/data/net/minecraft/world/level/levelgen/GeodeBlockSettings.mapping
@@ -9,4 +9,4 @@ CLASS net/minecraft/world/level/levelgen/GeodeBlockSettings
 		ARG 7 cannotReplace
 		ARG 8 invalidBlocks
 	METHOD lambda$static$8 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codec
+		ARG 0 instance

--- a/data/net/minecraft/world/level/levelgen/GeodeCrackSettings.mapping
+++ b/data/net/minecraft/world/level/levelgen/GeodeCrackSettings.mapping
@@ -4,4 +4,4 @@ CLASS net/minecraft/world/level/levelgen/GeodeCrackSettings
 		ARG 3 baseCrackSize
 		ARG 5 crackPointOffset
 	METHOD lambda$static$3 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codec
+		ARG 0 instance

--- a/data/net/minecraft/world/level/levelgen/GeodeLayerSettings.mapping
+++ b/data/net/minecraft/world/level/levelgen/GeodeLayerSettings.mapping
@@ -5,4 +5,4 @@ CLASS net/minecraft/world/level/levelgen/GeodeLayerSettings
 		ARG 5 middleLayer
 		ARG 7 outerLayer
 	METHOD lambda$static$4 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 codec
+		ARG 0 instance

--- a/data/net/minecraft/world/level/levelgen/feature/foliageplacers/BlobFoliagePlacer.mapping
+++ b/data/net/minecraft/world/level/levelgen/feature/foliageplacers/BlobFoliagePlacer.mapping
@@ -4,4 +4,6 @@ CLASS net/minecraft/world/level/levelgen/feature/foliageplacers/BlobFoliagePlace
 		ARG 2 offset
 		ARG 3 height
 	METHOD blobParts (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/Products$P3;
-		ARG 0 codecBuilder
+		ARG 0 instance
+	METHOD lambda$static$0 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance

--- a/data/net/minecraft/world/level/levelgen/structure/Structure.mapping
+++ b/data/net/minecraft/world/level/levelgen/structure/Structure.mapping
@@ -50,6 +50,10 @@ CLASS net/minecraft/world/level/levelgen/structure/Structure
 		ARG 1 context
 	METHOD lambda$findValidGenerationPoint$2 (Lnet/minecraft/world/level/levelgen/structure/Structure$GenerationContext;Lnet/minecraft/world/level/levelgen/structure/Structure$GenerationStub;)Z
 		ARG 1 stub
+	METHOD lambda$settingsCodec$0 (Lnet/minecraft/world/level/levelgen/structure/Structure;)Lnet/minecraft/world/level/levelgen/structure/Structure$StructureSettings;
+		ARG 0 structure
+	METHOD lambda$simpleCodec$1 (Ljava/util/function/Function;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 1 instance
 	METHOD onTopOfChunkCenter (Lnet/minecraft/world/level/levelgen/structure/Structure$GenerationContext;Lnet/minecraft/world/level/levelgen/Heightmap$Types;Ljava/util/function/Consumer;)Ljava/util/Optional;
 		ARG 0 context
 		ARG 1 heightmapTypes


### PR DESCRIPTION
`codec` is a bad name, it's not the codec, other things are bad and/or too long and `instance` is the functional-wanker-y-correct name.