### PR TITLE
Update Enigma to 2.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     remapper 'net.minecraftforge:ForgeAutoRenamingTool:1.0.2'
 
     // Enigma, pretty interface for editing mappings
-    enigma 'cuchaz:enigma-swing:2.3.2'
+    enigma 'cuchaz:enigma-swing:2.3.3'
 
     // ParchmentJAM, JAMMER integration for migrating mapping data
     jammer 'org.parchmentmc.jam:jam-parchment:0.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     remapper 'net.minecraftforge:ForgeAutoRenamingTool:1.0.2'
 
     // Enigma, pretty interface for editing mappings
-    enigma 'cuchaz:enigma-swing:2.3.1'
+    enigma 'cuchaz:enigma-swing:2.3.2'
 
     // ParchmentJAM, JAMMER integration for migrating mapping data
     jammer 'org.parchmentmc.jam:jam-parchment:0.1.0'


### PR DESCRIPTION
Updates Enigma to the latest version. See the Enigma commit log for [2.3.2](https://github.com/FabricMC/Enigma/compare/853a8c731345f883724a2f9b459c5d07ce013cce...88b412cd7e798ba1b5cf4b17c79292d1fc99de8f) and for [2.3.3](https://github.com/FabricMC/Enigma/compare/88b412cd7e798ba1b5cf4b17c79292d1fc99de8f...d93eae96a95f619d731630c6538d370ba4ae30ec) for details.