### PR TITLE
Fixed a typo in Block.java appendHoverText method.

### DIFF
--- a/data/net/minecraft/world/level/block/Block.mapping
+++ b/data/net/minecraft/world/level/block/Block.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/world/level/block/Block
 	METHOD appendHoverText (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/Item$TooltipContext;Ljava/util/List;Lnet/minecraft/world/item/TooltipFlag;)V
 		ARG 1 stack
 		ARG 2 context
-		ARG 3 tootipComponents
+		ARG 3 tooltipComponents
 		ARG 4 tooltipFlag
 	METHOD box (DDDDDD)Lnet/minecraft/world/phys/shapes/VoxelShape;
 		ARG 0 x1


### PR DESCRIPTION
For the arg of type `TooltipContext` the parameter name was missing the l.

Old image with typo:
![image](https://github.com/ParchmentMC/Parchment/assets/49323171/37e3da42-ed42-4d64-bcc4-676af276ff22)