### PR TITLE
Remove erroneous deprecations from methods in BlockBehaviour

### DIFF
--- a/data/net/minecraft/world/level/block/state/BlockBehaviour.mapping
+++ b/data/net/minecraft/world/level/block/state/BlockBehaviour.mapping
@@ -28,7 +28,6 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 	METHOD getAnalogOutputSignal (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)I
 		COMMENT Returns the analog signal this block emits. This is the signal a comparator can read from it.
 		COMMENT
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getAnalogOutputSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos
@@ -43,7 +42,6 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 4 context
 	METHOD getDestroyProgress (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)F
 		COMMENT Get the hardness of this Block relative to the ability of the given player
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getDestroyProgress} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 player
 		ARG 3 level
@@ -55,7 +53,6 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		COMMENT NOTE: directions in redstone signal related methods are backwards, so this method
 		COMMENT checks for the signal emitted in the <i>opposite</i> direction of the one given.
 		COMMENT
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getDirectSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos
@@ -83,7 +80,6 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 3 pos
 	METHOD getRenderShape (Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/block/RenderShape;
 		COMMENT The type of render function called. MODEL for mixed tesr and static model, MODELBLOCK_ANIMATED for TESR-only, LIQUID for vanilla liquids, INVISIBLE to skip all rendering
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getRenderShape} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 	METHOD getSeed (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;)J
 		COMMENT Return a random long to be passed to {@link net.minecraft.client.resources.model.BakedModel#getQuads}, used for random model rotations
@@ -105,7 +101,6 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		COMMENT NOTE: directions in redstone signal related methods are backwards, so this method
 		COMMENT checks for the signal emitted in the <i>opposite</i> direction of the one given.
 		COMMENT
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#getSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos
@@ -118,7 +113,6 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 3 pos
 		ARG 4 context
 	METHOD hasAnalogOutputSignal (Lnet/minecraft/world/level/block/state/BlockState;)Z
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#hasAnalogOutputSignal} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 	METHOD isCollisionShapeFullBlock (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z
 		ARG 1 state
@@ -136,11 +130,9 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 	METHOD isSignalSource (Lnet/minecraft/world/level/block/state/BlockState;)Z
 		COMMENT Returns whether this block is capable of emitting redstone signals.
 		COMMENT
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#isSignalSource} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 	METHOD mirror (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/Mirror;)Lnet/minecraft/world/level/block/state/BlockState;
 		COMMENT Returns the blockstate with the given mirror of the passed blockstate. If inapplicable, returns the passed blockstate.
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#mirror} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 mirror
 	METHOD neighborChanged (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Block;Lnet/minecraft/core/BlockPos;Z)V
@@ -185,7 +177,6 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 4 random
 	METHOD rotate (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/Rotation;)Lnet/minecraft/world/level/block/state/BlockState;
 		COMMENT Returns the blockstate with the given rotation from the passed blockstate. If inapplicable, returns the passed blockstate.
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#rotate} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 rotation
 	METHOD simpleCodec (Ljava/util/function/Function;)Lcom/mojang/serialization/MapCodec;
@@ -208,7 +199,6 @@ CLASS net/minecraft/world/level/block/state/BlockBehaviour
 		ARG 4 random
 	METHOD triggerEvent (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;II)Z
 		COMMENT Called on server when {@link net.minecraft.world.level.Level#blockEvent} is called. If server returns true, then also called on the client. On the Server, this may perform additional changes to the world, like pistons replacing the block with an extended base. On the client, the update may involve replacing block entities or effects such as sounds or particles
-		COMMENT @deprecated call via {@link net.minecraft.world.level.block.state.BlockBehaviour.BlockStateBase#triggerEvent} whenever possible. Implementing/overriding is fine.
 		ARG 1 state
 		ARG 2 level
 		ARG 3 pos


### PR DESCRIPTION
This PR removes the remaining deprecations from methods in `BlockBehaviour`. These methods were previously public and marked deprecated to indicate that they should not be called directly on a `Block`. In 1.21 these methods were switched to protected and the deprecation was removed. The deprecation tags in the docs however still cause IDEs to consider them deprecated.