### PR TITLE
fix some incorrect mappings

### DIFF
--- a/data/net/minecraft/server/level/ServerPlayer.mapping
+++ b/data/net/minecraft/server/level/ServerPlayer.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/server/level/ServerPlayer
 		ARG 3 gameProfile
 		ARG 4 clientInformation
 	METHOD acceptsSystemMessages (Z)Z
-		ARG 1 bypassHiddenChat
+		ARG 1 overlay
 	METHOD addAdditionalSaveData (Lnet/minecraft/nbt/CompoundTag;)V
 		ARG 1 compound
 	METHOD attack (Lnet/minecraft/world/entity/Entity;)V
@@ -195,7 +195,7 @@ CLASS net/minecraft/server/level/ServerPlayer
 		ARG 1 serverStatus
 	METHOD sendSystemMessage (Lnet/minecraft/network/chat/Component;Z)V
 		ARG 1 component
-		ARG 2 bypassHiddenChat
+		ARG 2 overlay
 	METHOD setCamera (Lnet/minecraft/world/entity/Entity;)V
 		ARG 1 entityToSpectate
 	METHOD setChatSession (Lnet/minecraft/network/chat/RemoteChatSession;)V

--- a/data/net/minecraft/server/level/ServerPlayer.mapping
+++ b/data/net/minecraft/server/level/ServerPlayer.mapping
@@ -74,7 +74,7 @@ CLASS net/minecraft/server/level/ServerPlayer
 		ARG 5 movementZ
 		ARG 7 onGround
 	METHOD doCloseContainer ()V
-		COMMENT Invoked when the container the player has opened is to be closed, either by a call to {@link #closeContainer} or a packet.
+		COMMENT Invoked when the active container of the player is to be closed, either by a call to {@link #closeContainer()} or a packet.
 	METHOD drop (Lnet/minecraft/world/item/ItemStack;ZZ)Lnet/minecraft/world/entity/item/ItemEntity;
 		ARG 1 droppedItem
 		ARG 2 dropAround

--- a/data/net/minecraft/server/level/ServerPlayer.mapping
+++ b/data/net/minecraft/server/level/ServerPlayer.mapping
@@ -51,7 +51,7 @@ CLASS net/minecraft/server/level/ServerPlayer
 		ARG 3 dy
 		ARG 5 dz
 	METHOD closeContainer ()V
-		COMMENT Sets the current crafting inventory back to the 2x2 square.
+		COMMENT Closes the container the player currently has open.
 	METHOD completeUsingItem ()V
 		COMMENT Used for when item use count runs out, ie: eating completed
 	METHOD copyRespawnPosition (Lnet/minecraft/server/level/ServerPlayer;)V
@@ -74,7 +74,7 @@ CLASS net/minecraft/server/level/ServerPlayer
 		ARG 5 movementZ
 		ARG 7 onGround
 	METHOD doCloseContainer ()V
-		COMMENT Closes the container the player currently has open.
+		COMMENT Invoked when the container the player has opened is to be closed, either by a call to {@link #closeContainer} or a packet.
 	METHOD drop (Lnet/minecraft/world/item/ItemStack;ZZ)Lnet/minecraft/world/entity/item/ItemEntity;
 		ARG 1 droppedItem
 		ARG 2 dropAround

--- a/data/net/minecraft/server/players/PlayerList.mapping
+++ b/data/net/minecraft/server/players/PlayerList.mapping
@@ -37,10 +37,10 @@ CLASS net/minecraft/server/players/PlayerList
 	METHOD broadcastSystemMessage (Lnet/minecraft/network/chat/Component;Ljava/util/function/Function;Z)V
 		ARG 1 serverMessage
 		ARG 2 playerMessageFactory
-		ARG 3 bypassHiddenChat
+		ARG 3 overlay
 	METHOD broadcastSystemMessage (Lnet/minecraft/network/chat/Component;Z)V
 		ARG 1 message
-		ARG 2 bypassHiddenChat
+		ARG 2 overlay
 	METHOD broadcastSystemToAllExceptTeam (Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/network/chat/Component;)V
 		ARG 1 player
 		ARG 2 message

--- a/data/net/minecraft/world/Container.mapping
+++ b/data/net/minecraft/world/Container.mapping
@@ -20,7 +20,7 @@ CLASS net/minecraft/world/Container
 		COMMENT Returns the stack in the given slot.
 		ARG 1 slot
 	METHOD getMaxStackSize ()I
-		COMMENT Returns the maximum stack size for an inventory slot. Seems to always be 64, possibly will be extended.
+		COMMENT Returns the maximum stack size for an inventory slot.
 	METHOD getMaxStackSize (Lnet/minecraft/world/item/ItemStack;)I
 		ARG 1 stack
 	METHOD hasAnyMatching (Ljava/util/function/Predicate;)Z
@@ -38,7 +38,7 @@ CLASS net/minecraft/world/Container
 		COMMENT Removes a stack from the given slot and returns it.
 		ARG 1 slot
 	METHOD setChanged ()V
-		COMMENT For block entities, ensures the chunk containing the block entity is saved to disk later - the game won't think it hasn't changed and skip it.
+		COMMENT Called whenever this container is changed.
 	METHOD setItem (ILnet/minecraft/world/item/ItemStack;)V
 		COMMENT Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
 		ARG 1 slot
@@ -46,7 +46,6 @@ CLASS net/minecraft/world/Container
 	METHOD startOpen (Lnet/minecraft/world/entity/player/Player;)V
 		ARG 1 player
 	METHOD stillValid (Lnet/minecraft/world/entity/player/Player;)Z
-		COMMENT Don't rename this method to canInteractWith due to conflicts with Container
 		ARG 1 player
 	METHOD stillValidBlockEntity (Lnet/minecraft/world/level/block/entity/BlockEntity;Lnet/minecraft/world/entity/player/Player;)Z
 		ARG 0 blockEntity

--- a/data/net/minecraft/world/Container.mapping
+++ b/data/net/minecraft/world/Container.mapping
@@ -38,7 +38,7 @@ CLASS net/minecraft/world/Container
 		COMMENT Removes a stack from the given slot and returns it.
 		ARG 1 slot
 	METHOD setChanged ()V
-		COMMENT Called whenever this container is changed.
+		COMMENT Called when the contents of this container have changed.
 	METHOD setItem (ILnet/minecraft/world/item/ItemStack;)V
 		COMMENT Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
 		ARG 1 slot


### PR DESCRIPTION
- ServerPlayer#sendSystemMessage's `bypassHiddenChat` is renamed to `overlay`, since it also controls whether the message goes to the action bar
- closeContainer and doCloseContainer's javadocs are changed to better reflect what they do
- Container's invalid stillValid javadoc is removed and some other javadocs are changed to fit the methods more