### PR TITLE
Rename RandomSource.triangle arguments

### DIFF
--- a/data/net/minecraft/util/RandomSource.mapping
+++ b/data/net/minecraft/util/RandomSource.mapping
@@ -19,5 +19,5 @@ CLASS net/minecraft/util/RandomSource
 	METHOD setSeed (J)V
 		ARG 1 seed
 	METHOD triangle (DD)D
-		ARG 1 min
-		ARG 3 max
+		ARG 1 center
+		ARG 3 maxDeviation


### PR DESCRIPTION
The code of the function is
```
default double triangle(double min, double max) {
        return min + max * (this.nextDouble() - this.nextDouble());
    }
```
It can return `min - max` or `min + max`. I believe the arguments should be named `center` and `maxDeviation`.