### PR TITLE
Add GitHub Actions to replace TeamCity as CI

### DIFF
--- a/.github/workflows/bleeding.yml
+++ b/.github/workflows/bleeding.yml
@@ -1,0 +1,78 @@
+on: 
+  workflow_dispatch:
+  push:
+
+name: Publish bleeding export
+
+jobs:
+  publish:
+    name: Publish export
+    runs-on: ubuntu-latest
+    outputs:
+      CI_VERSION: ${{ steps.info.outputs.CI_VERSION }}
+      CI_GROUP: ${{ steps.info.outputs.CI_GROUP }}
+      CI_ARTIFACT: ${{ steps.info.outputs.CI_ARTIFACT }}
+      CI_GAME_VERSION: ${{ steps.info.outputs.CI_GAME_VERSION }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Obtain GAV info
+        id: info
+        run: ./gradlew --quiet printGHActionsOutput >> "$GITHUB_OUTPUT"
+  
+      - name: Publish export
+        run: ./gradlew publishExport -PreleaseType=bleeding
+        env:
+          LDTTeamJfrogUsername: ${{ secrets.PUBLISHING_USERNAME }}
+          LDTTeamJfrogPassword: ${{ secrets.PUBLISHING_PASSWORD }}
+  announce:
+    name: Send announcement message
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download discord.sh
+        run: curl -LOJ https://github.com/fieu/discord.sh/releases/download/v2.0.0/discord.sh
+
+      - name: Set discord.sh executable
+        run: chmod +x discord.sh
+
+      - name: Send announcement message
+        run: |
+          ./discord.sh \
+            --webhook-url="$WEBHOOK" \
+            --username "ParchmentMC" \
+            --color "0xFF0000" \
+            --title "New bleeding for \`$CI_GAME_VERSION!\`" \
+            --field "Version;\`$CI_VERSION\`;false" \
+            --field "Group;\`$CI_GROUP\`;true" \
+            --field "Artifact;\`$CI_ARTIFACT\`;true" \
+            --field "Coordinate;\`$CI_GROUP:$CI_ARTIFACT:$CI_VERSION\`;false" \
+            --timestamp
+        env:
+          WEBHOOK: ${{ secrets.BLEEDING_DISCORD_WEBHOOK }}
+          CI_VERSION: ${{ needs.publish.outputs.CI_VERSION }}
+          CI_GROUP: ${{ needs.publish.outputs.CI_GROUP }}
+          CI_ARTIFACT: ${{ needs.publish.outputs.CI_ARTIFACT }}
+          CI_GAME_VERSION: ${{ needs.publish.outputs.CI_GAME_VERSION }}
+  set-variables:
+    name: Set repository variables
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark pending variables
+        run: |
+          gh -R $GITHUB_SERVER_URL/$GITHUB_REPOSITORY variable set HAS_PENDING_NIGHTLY --body "true"
+          gh -R $GITHUB_SERVER_URL/$GITHUB_REPOSITORY variable set HAS_PENDING_RELEASE --body "true"
+        env: 
+          # This should be a GH PAT with 'repo' scope
+          GH_TOKEN: ${{ secrets.VARIABLES_GH_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,81 @@
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * *" # 12NN every day
+
+name: Publish nightly export
+
+jobs:
+  publish:
+    name: Publish export
+    runs-on: ubuntu-latest
+    # If triggered by schedule, only run if the variable is set to true
+    # (This allows the workflow to be triggered manually)
+    if: ${{ github.event_name != 'schedule' || fromJSON(vars.HAS_PENDING_NIGHTLY) == true }}
+    outputs:
+      CI_VERSION: ${{ steps.info.outputs.CI_VERSION }}
+      CI_GROUP: ${{ steps.info.outputs.CI_GROUP }}
+      CI_ARTIFACT: ${{ steps.info.outputs.CI_ARTIFACT }}
+      CI_GAME_VERSION: ${{ steps.info.outputs.CI_GAME_VERSION }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Obtain GAV info
+        id: info
+        run: ./gradlew --quiet printGHActionsOutput >> "$GITHUB_OUTPUT"
+  
+      - name: Publish export
+        run: ./gradlew publishExport -PreleaseType=nightly
+        env:
+          LDTTeamJfrogUsername: ${{ secrets.PUBLISHING_USERNAME }}
+          LDTTeamJfrogPassword: ${{ secrets.PUBLISHING_PASSWORD }}
+  announce:
+    name: Send announcement message
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download discord.sh
+        run: curl -LOJ https://github.com/fieu/discord.sh/releases/download/v2.0.0/discord.sh
+
+      - name: Set discord.sh executable
+        run: chmod +x discord.sh
+
+      - name: Send announcement message
+        run: |
+          ./discord.sh \
+            --webhook-url="$WEBHOOK" \
+            --username "ParchmentMC" \
+            --color "0xFFA500" \
+            --title "New nightly for \`$CI_GAME_VERSION!\`" \
+            --field "Version;\`$CI_VERSION\`;false" \
+            --field "Group;\`$CI_GROUP\`;true" \
+            --field "Artifact;\`$CI_ARTIFACT\`;true" \
+            --field "Coordinate;\`$CI_GROUP:$CI_ARTIFACT:$CI_VERSION\`;false" \
+            --timestamp
+        env:
+          WEBHOOK: ${{ secrets.NIGHTLY_DISCORD_WEBHOOK }}
+          CI_VERSION: ${{ needs.publish.outputs.CI_VERSION }}
+          CI_GROUP: ${{ needs.publish.outputs.CI_GROUP }}
+          CI_ARTIFACT: ${{ needs.publish.outputs.CI_ARTIFACT }}
+          CI_GAME_VERSION: ${{ needs.publish.outputs.CI_GAME_VERSION }}
+  set-variables:
+    name: Set repository variables
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unmark pending variable
+        run: |
+          gh -R $GITHUB_SERVER_URL/$GITHUB_REPOSITORY variable set HAS_PENDING_NIGHTLY --body "false"
+        env: 
+          # This should be a GH PAT with 'repo' scope
+          GH_TOKEN: ${{ secrets.VARIABLES_GH_TOKEN }}

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -1,0 +1,30 @@
+on:
+  - pull_request
+
+name: Validate PR
+
+jobs:
+  build:
+    name: Build and validate PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run validation task
+        run: ./gradlew validateData
+
+      - name: Upload ZIPs
+        uses: actions/upload-artifact@v4
+        with:
+          name: export-zips
+          path: build/exportZips/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 0" # 12NN on Sundays
+
+name: Publish release export
+
+permissions:
+  contents: write # For creating and pushing the tag
+
+jobs:
+  publish:
+    name: Publish export
+    runs-on: ubuntu-latest
+    # If triggered by schedule, only run if the variable is set to true
+    # (This allows the workflow to be triggered manually)
+    if: ${{ github.event_name != 'schedule' || fromJSON(vars.HAS_PENDING_RELEASE) == true }}
+    outputs:
+      CI_VERSION: ${{ steps.info.outputs.CI_VERSION }}
+      CI_GROUP: ${{ steps.info.outputs.CI_GROUP }}
+      CI_ARTIFACT: ${{ steps.info.outputs.CI_ARTIFACT }}
+      CI_GAME_VERSION: ${{ steps.info.outputs.CI_GAME_VERSION }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Obtain GAV info
+        id: info
+        run: ./gradlew --quiet printGHActionsOutput >> "$GITHUB_OUTPUT"
+  
+      - name: Publish export
+        run: ./gradlew publishExport -PreleaseType=release
+        env:
+          LDTTeamJfrogUsername: ${{ secrets.PUBLISHING_USERNAME }}
+          LDTTeamJfrogPassword: ${{ secrets.PUBLISHING_PASSWORD }}
+  create-tag:
+    name: Create tag
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/releases/${{ needs.publish.outputs.CI_GAME_VERSION }}-${{ needs.publish.outputs.CI_VERSION }}',
+              sha: context.sha
+            })
+  announce:
+    name: Send announcement message
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download discord.sh
+        run: curl -LOJ https://github.com/fieu/discord.sh/releases/download/v2.0.0/discord.sh
+
+      - name: Set discord.sh executable
+        run: chmod +x discord.sh
+
+      - name: Send announcement message
+        run: |
+          ./discord.sh \
+            --webhook-url="$WEBHOOK" \
+            --username "ParchmentMC" \
+            --color "0x228B22" \
+            --title "New release for \`$CI_GAME_VERSION!\`" \
+            --field "Version;\`$CI_VERSION\`;false" \
+            --field "Group;\`$CI_GROUP\`;true" \
+            --field "Artifact;\`$CI_ARTIFACT\`;true" \
+            --field "Coordinate;\`$CI_GROUP:$CI_ARTIFACT:$CI_VERSION\`;false" \
+            --timestamp
+        env:
+          WEBHOOK: ${{ secrets.RELEASES_DISCORD_WEBHOOK }}
+          CI_VERSION: ${{ needs.publish.outputs.CI_VERSION }}
+          CI_GROUP: ${{ needs.publish.outputs.CI_GROUP }}
+          CI_ARTIFACT: ${{ needs.publish.outputs.CI_ARTIFACT }}
+          CI_GAME_VERSION: ${{ needs.publish.outputs.CI_GAME_VERSION }}
+  set-variables:
+    name: Set repository variables
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unmark pending variables
+        run: |
+          gh -R $GITHUB_SERVER_URL/$GITHUB_REPOSITORY variable set HAS_PENDING_RELEASE --body "false"
+        env: 
+          # This should be a GH PAT with 'repo' scope
+          GH_TOKEN: ${{ secrets.VARIABLES_GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 Parchment Mappings
 ==================
 [![Discord server badge](https://img.shields.io/discord/851855518398152725?color=5865F2&label=discord&logo=discord&logoColor=white)](https://discord.parchmentmc.org/)
-[![Minecraft version badge](https://img.shields.io/badge/mc%20version-1.21-3b8526)](#)
+![Minecraft version badge](https://img.shields.io/badge/mc%20version-1.21-3b8526)
 &nbsp;
-[![Latest release version badge](https://img.shields.io/maven-metadata/v?color=forestgreen&label=release&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-internal%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.21%2Fmaven-metadata.xml)](#)
-[![CI release build status](https://github.com/ParchmentMC/Parchment/actions/workflows/release.yml/badge.svg)](#)
+![Latest release version badge](https://img.shields.io/maven-metadata/v?color=forestgreen&label=release&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-internal%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.21%2Fmaven-metadata.xml)
+![CI release build status](https://github.com/ParchmentMC/Parchment/actions/workflows/release.yml/badge.svg)
 
-[![Latest nightly version badge](https://img.shields.io/maven-metadata/v?color=orange&label=nightly&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-snapshots%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.21%2Fmaven-metadata.xml)](#)
-[![CI nightly build status](https://github.com/ParchmentMC/Parchment/actions/workflows/nightly.yml/badge.svg)](#)
+![Latest nightly version badge](https://img.shields.io/maven-metadata/v?color=orange&label=nightly&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-snapshots%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.21%2Fmaven-metadata.xml)
+![CI nightly build status](https://github.com/ParchmentMC/Parchment/actions/workflows/nightly.yml/badge.svg)
 &nbsp;
-[![Latest bleeding version badge](https://img.shields.io/maven-metadata/v?color=red&label=bleeding&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-bleeding%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.21%2Fmaven-metadata.xml)](#)
-[![CI bleeding build status](https://github.com/ParchmentMC/Parchment/actions/workflows/bleeding.yml/badge.svg)](#)
+![Latest bleeding version badge](https://img.shields.io/maven-metadata/v?color=red&label=bleeding&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-bleeding%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.21%2Fmaven-metadata.xml)
+![CI bleeding build status](https://github.com/ParchmentMC/Parchment/actions/workflows/bleeding.yml/badge.svg)
 
 Welcome to the Parchment mappings repository!
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Parchment Mappings
 [![Minecraft version badge](https://img.shields.io/badge/mc%20version-1.21-3b8526)](#)
 &nbsp;
 [![Latest release version badge](https://img.shields.io/maven-metadata/v?color=forestgreen&label=release&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-internal%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.21%2Fmaven-metadata.xml)](#)
-[![CI release build status](https://buildsystem.ldtteam.com/app/rest/builds/buildType:(id:ParchmentMC_Mappings_Release),branch:1.21.x/statusIcon)](#)
+[![CI release build status](https://github.com/ParchmentMC/Parchment/actions/workflows/release.yml/badge.svg)](#)
 
 [![Latest nightly version badge](https://img.shields.io/maven-metadata/v?color=orange&label=nightly&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-snapshots%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.21%2Fmaven-metadata.xml)](#)
-[![CI nightly build status](https://buildsystem.ldtteam.com/app/rest/builds/buildType:(id:ParchmentMC_Mappings_Nightly),branch:1.21.x/statusIcon)](#)
+[![CI nightly build status](https://github.com/ParchmentMC/Parchment/actions/workflows/nightly.yml/badge.svg)](#)
 &nbsp;
 [![Latest bleeding version badge](https://img.shields.io/maven-metadata/v?color=red&label=bleeding&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-bleeding%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.21%2Fmaven-metadata.xml)](#)
-[![CI bleeding build status](https://buildsystem.ldtteam.com/app/rest/builds/buildType:(id:ParchmentMC_Mappings_Bleeding),branch:1.21.x/statusIcon)](#)
+[![CI bleeding build status](https://github.com/ParchmentMC/Parchment/actions/workflows/bleeding.yml/badge.svg)](#)
 
 Welcome to the Parchment mappings repository!
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,10 @@ final isBleeding = releaseType.toString() == 'bleeding'
 if (isBleeding) {
     version = 'BLEEDING-SNAPSHOT'
 }
-println("Version: $version")
+// Only output if not in CI
+if (!Boolean.parseBoolean(System.getenv("CI"))){
+    println("Version: $version")
+}
 
 writtenbooks {
     snapshotVersion = !isRelease
@@ -75,14 +78,12 @@ dependencies {
     jammer 'org.parchmentmc.jam:jam-parchment:0.1.0'
 }
 
-afterEvaluate {
-    final isCI = Boolean.parseBoolean(project.findProperty('isCI') as String)
-    if (isCI) {
-        println('Running on CI.')
-        println("##teamcity[setParameter name='env.CI_VERSION' value='$version']")
-        println("##teamcity[setParameter name='env.CI_GROUP' value='$group']")
-        println("##teamcity[setParameter name='env.CI_ARTIFACT' value='parchment-${project.compass.version.get()}']")
-        println("##teamcity[setParameter name='env.CI_GAME_VERSION' value='${project.compass.version.get()}']")
+tasks.register('printGHActionsOutput') {
+    doLast {
+        println("CI_VERSION=${project.version}")
+        println("CI_GROUP=${project.group}")
+        println("CI_ARTIFACT=parchment-${"1.21.3"}")
+        println("CI_GAME_VERSION=${"1.21.3"}")
     }
 }
 


### PR DESCRIPTION
As many of us are (painfully) aware, a few months ago, the LDTTeam TeamCity was shut down due to various reasons such as operating costs. That TeamCity instance ran all of the CI for ParchmentMC, so work on Parchment mappings ground to a standstill until we replaced the now-dead TeamCity with another CI solution.

Of course, the natural replacement (and the one that LDTTeam ran with, even) was [GitHub Actions](https://github.com/features/actions), an on-platform integrated CI solution running off YAML files stored in the repository, which GitHub grants free access to public repositories. The majority of projects in the Minecraft modding space (or at least, those I know of) use GitHub Actions for their build and release workflows, due to its simplicity, ease of use, and availability (since it's available for any repository on GitHub).

What remained was writing up the GitHub Action files to replace the TeamCity build configurations. As toolchain lead, it is my responsibility to do that, partly because without access to the old TeamCity instance, I'm nearly the only one with the (semi-)working memory on what the build configurations even did in the first place. That compounded with my own personal/academic life, and general pain in figuring out what best to start with for writing the GitHub Actions.

But after all that, we (finally!) now have the replacement GitHub Actions workflows for the TeamCity build configurations. I've looked at them twice now, and they _look_ fine to me, but the true test will of course be in production. (Cue "testing in production" memes here.) I've also worked with @marchermans to get the credentials to the LDTTeam JFrog (which powers our Maven repository) fixed up and ready.

---

What's left after this PR? Fixing bugs with the workflows if any (though hopefully not), reviewing all of the backlogged PRs starting from oldest to newest, and then working on making GitHub Action workflows for *all* the ParchmentMC repositories which relied on TeamCity previously.

Particularly, Blackstone is next on the list to be GitHub Action'd, since that is required for validation and sanitation for the new MC versions. However, I'll probably just run and publish Blackstone manually for the few versions that don't have one yet since TeamCity was shut down, and work on automating that within the next few months.