### PR TITLE
Update comment of `AbstractContainerMenu#clickMenuButton`

### DIFF
--- a/data/net/minecraft/world/inventory/AbstractContainerMenu.mapping
+++ b/data/net/minecraft/world/inventory/AbstractContainerMenu.mapping
@@ -47,7 +47,7 @@ CLASS net/minecraft/world/inventory/AbstractContainerMenu
 		ARG 1 player
 		ARG 2 container
 	METHOD clickMenuButton (Lnet/minecraft/world/entity/player/Player;I)Z
-		COMMENT Handles the given Button-click on the server, currently only used by enchanting. Name is for legacy.
+		COMMENT Handles the given Button-click on the server, currently used by enchanting table, loom, lectern and stonecutter. Name is for legacy.
 		ARG 1 player
 		ARG 2 id
 	METHOD clicked (IILnet/minecraft/world/inventory/ClickType;Lnet/minecraft/world/entity/player/Player;)V


### PR DESCRIPTION
In the recent version, method `net.minecraft.world.inventory.AbstractContainerMenu#clickMenuButton` has been override by `LecternMenu`, `LoomMenu` and `StonecutterMenu`.