### PR TITLE
Fix typo in the first argument of `n.m.c.gui.font.providers.BitmapProvider#load(...)`

### DIFF
--- a/data/net/minecraft/client/gui/font/providers/BitmapProvider.mapping
+++ b/data/net/minecraft/client/gui/font/providers/BitmapProvider.mapping
@@ -20,7 +20,7 @@ CLASS net/minecraft/client/gui/font/providers/BitmapProvider
 			ARG 4 x
 			ARG 5 y
 		METHOD load (Lnet/minecraft/server/packs/resources/ResourceManager;)Lcom/mojang/blaze3d/font/GlyphProvider;
-			ARG 1 resoureManager
+			ARG 1 resourceManager
 		METHOD validate (Lnet/minecraft/client/gui/font/providers/BitmapProvider$Definition;)Lcom/mojang/serialization/DataResult;
 			ARG 0 definition
 		METHOD validateDimensions ([[I)Lcom/mojang/serialization/DataResult;


### PR DESCRIPTION
`resoureManager` -> `resourceManager` :christmas_tree: 