### PR TITLE
Fix parameter shadow in `DownloadCacheCleaner`

### DIFF
--- a/data/net/minecraft/server/packs/DownloadCacheCleaner.mapping
+++ b/data/net/minecraft/server/packs/DownloadCacheCleaner.mapping
@@ -8,5 +8,5 @@ CLASS net/minecraft/server/packs/DownloadCacheCleaner
 		ARG 1 maxEntries
 	CLASS 1
 		METHOD visitFile (Ljava/nio/file/Path;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;
-			ARG 1 path
-			ARG 2 file
+			ARG 1 file
+			ARG 2 attributes


### PR DESCRIPTION
During the 1.20.4 port both the in path parameter and the parameter of the anonymous class method in `vacuumCacheDir` were named `path` therefore leading to the outer variable being shadowed by the inner one.