### PR TITLE
Fix incorrectly named param in Consumable

### DIFF
--- a/data/net/minecraft/world/item/component/Consumable.mapping
+++ b/data/net/minecraft/world/item/component/Consumable.mapping
@@ -23,7 +23,7 @@ CLASS net/minecraft/world/item/component/Consumable
 		METHOD animation (Lnet/minecraft/world/item/ItemUseAnimation;)Lnet/minecraft/world/item/component/Consumable$Builder;
 			ARG 1 animation
 		METHOD consumeSeconds (F)Lnet/minecraft/world/item/component/Consumable$Builder;
-			ARG 1 consumeSounds
+			ARG 1 consumeSeconds
 		METHOD hasConsumeParticles (Z)Lnet/minecraft/world/item/component/Consumable$Builder;
 			ARG 1 hasConsumeParticles
 		METHOD onConsume (Lnet/minecraft/world/item/consume_effects/ConsumeEffect;)Lnet/minecraft/world/item/component/Consumable$Builder;


### PR DESCRIPTION
The consumable Builder here is assigning value to consumeSeconds(Mojang mapping), but the parameter passed in is incorrectly named as `consumeSounds`

![image](https://github.com/user-attachments/assets/5d293ec7-afd4-4f8d-84e4-fa372c4ebdab)
