### PR TITLE
Fix incorrectly named parameter in VertexConsumer#putBulkData

### DIFF
--- a/data/com/mojang/blaze3d/vertex/VertexConsumer.mapping
+++ b/data/com/mojang/blaze3d/vertex/VertexConsumer.mapping
@@ -49,7 +49,7 @@ CLASS com/mojang/blaze3d/vertex/VertexConsumer
 		ARG 7 alpha
 		ARG 8 lightmap
 		ARG 9 packedOverlay
-		ARG 10 readAlpha
+		ARG 10 readExistingColor
 	METHOD setColor (FFFF)Lcom/mojang/blaze3d/vertex/VertexConsumer;
 		ARG 1 red
 		ARG 2 green


### PR DESCRIPTION
The boolean parameter in `VertexConsumer#putBulkData()` controls whether the entire color is read from the quad's vertex data, not just whether the alpha value is read.