### PR TITLE
Incorrect GuiEventListener#charTyped param mapping

### DIFF
--- a/data/net/minecraft/client/gui/components/events/GuiEventListener.mapping
+++ b/data/net/minecraft/client/gui/components/events/GuiEventListener.mapping
@@ -6,8 +6,8 @@ CLASS net/minecraft/client/gui/components/events/GuiEventListener
 		COMMENT Called when a character is typed within the GUI element.
 		COMMENT <p>
 		COMMENT @return {@code true} if the event is consumed, {@code false} otherwise.
-		ARG 1 codePoint
-			COMMENT the code point of the typed character.
+		ARG 1 character
+			COMMENT the typed character.
 		ARG 2 modifiers
 			COMMENT the keyboard modifiers.
 	METHOD getBorderForArrowNavigation (Lnet/minecraft/client/gui/navigation/ScreenDirection;)Lnet/minecraft/client/gui/navigation/ScreenRectangle;


### PR DESCRIPTION
This param is not the codepoint.

KeyboardHandler converts the codepoint into high/low surrogate and sends individual event for each. This is the snippet of that code:

```java
	private void charTyped(long windowPointer, int codePoint, int modifiers) {
		if (windowPointer == this.minecraft.getWindow().getWindow()) {
			Screen screen = this.minecraft.screen;
			if (screen != null && this.minecraft.getOverlay() == null) {
				try {
					if (Character.isBmpCodePoint(codePoint)) {
						screen.charTyped((char)codePoint, modifiers);
					} else if (Character.isValidCodePoint(codePoint)) {
						screen.charTyped(Character.highSurrogate(codePoint), modifiers);
						screen.charTyped(Character.lowSurrogate(codePoint), modifiers);
					}
```