### PR TITLE
Fix various mistakes

### DIFF
--- a/data/com/mojang/blaze3d/platform/NativeImage.mapping
+++ b/data/com/mojang/blaze3d/platform/NativeImage.mapping
@@ -29,7 +29,7 @@ CLASS com/mojang/blaze3d/platform/NativeImage
 		ARG 7 mirrorX
 		ARG 8 mirrorY
 	METHOD copyRect (Lcom/mojang/blaze3d/platform/NativeImage;IIIIIIZZ)V
-		ARG 1 source
+		ARG 1 target
 		ARG 2 xFrom
 		ARG 3 yFrom
 		ARG 4 xTo

--- a/data/net/minecraft/client/data/models/model/ItemModelUtils.mapping
+++ b/data/net/minecraft/client/data/models/model/ItemModelUtils.mapping
@@ -18,8 +18,8 @@ CLASS net/minecraft/client/data/models/model/ItemModelUtils
 	METHOD lambda$selectBlockItemProperty$0 (Lnet/minecraft/world/level/block/state/properties/Property;Ljava/util/Map$Entry;)Lnet/minecraft/client/renderer/item/SelectItemModel$SwitchCase;
 		ARG 1 entry
 	METHOD override (Lnet/minecraft/client/renderer/item/ItemModel$Unbaked;F)Lnet/minecraft/client/renderer/item/RangeSelectItemModel$Entry;
-		ARG 0 threshold
-		ARG 1 model
+		ARG 0 model
+		ARG 1 threshold
 	METHOD plainModel (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/renderer/item/ItemModel$Unbaked;
 		ARG 0 model
 	METHOD rangeSelect (Lnet/minecraft/client/renderer/item/properties/numeric/RangeSelectItemModelProperty;FLjava/util/List;)Lnet/minecraft/client/renderer/item/ItemModel$Unbaked;

--- a/data/net/minecraft/client/gui/components/AbstractWidget.mapping
+++ b/data/net/minecraft/client/gui/components/AbstractWidget.mapping
@@ -47,7 +47,7 @@ CLASS net/minecraft/client/gui/components/AbstractWidget
 	METHOD renderScrollingString (Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/gui/Font;II)V
 		ARG 1 guiGraphics
 		ARG 2 font
-		ARG 3 width
+		ARG 3 padding
 		ARG 4 color
 	METHOD renderScrollingString (Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;IIIII)V
 		ARG 0 guiGraphics

--- a/data/net/minecraft/client/gui/render/GuiRenderer.mapping
+++ b/data/net/minecraft/client/gui/render/GuiRenderer.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/client/gui/render/GuiRenderer
 	METHOD createAtlasTextures (I)V
 		ARG 1 atlasSize
 	METHOD draw (Lcom/mojang/blaze3d/buffers/GpuBufferSlice;)V
-		ARG 1 bufferSlice
+		ARG 1 fogUniforms
 	METHOD enableScissor (Lnet/minecraft/client/gui/navigation/ScreenRectangle;Lcom/mojang/blaze3d/systems/RenderPass;)V
 		ARG 1 scissorArea
 		ARG 2 renderPass
@@ -25,7 +25,7 @@ CLASS net/minecraft/client/gui/render/GuiRenderer
 	METHOD executeDrawRange (Ljava/util/function/Supplier;Lcom/mojang/blaze3d/pipeline/RenderTarget;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lcom/mojang/blaze3d/buffers/GpuBuffer;Lcom/mojang/blaze3d/vertex/VertexFormat$IndexType;II)V
 		ARG 1 debugGroup
 		ARG 2 renderTarget
-		ARG 3 fog
+		ARG 3 fogUniforms
 		ARG 4 dynamicTransforms
 		ARG 5 buffer
 		ARG 6 indexType

--- a/data/net/minecraft/client/renderer/block/model/BlockModelDefinition.mapping
+++ b/data/net/minecraft/client/renderer/block/model/BlockModelDefinition.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/client/renderer/block/model/BlockModelDefinition
 		ARG 1 other
 	METHOD instantiate (Lnet/minecraft/world/level/block/state/StateDefinition;Ljava/util/function/Supplier;)Ljava/util/Map;
 		ARG 1 stateDefinition
-		ARG 2 name
+		ARG 2 sourceSupplier
 	METHOD lambda$static$0 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
 	CLASS MultiPartDefinition
@@ -12,5 +12,5 @@ CLASS net/minecraft/client/renderer/block/model/BlockModelDefinition
 	CLASS SimpleModelSelectors
 		METHOD instantiate (Lnet/minecraft/world/level/block/state/StateDefinition;Ljava/util/function/Supplier;Ljava/util/function/BiConsumer;)V
 			ARG 1 stateDefinition
-			ARG 2 name
+			ARG 2 sourceSupplier
 			ARG 3 output

--- a/data/net/minecraft/core/SectionPos.mapping
+++ b/data/net/minecraft/core/SectionPos.mapping
@@ -12,9 +12,9 @@ CLASS net/minecraft/core/SectionPos
 		ARG 1 consumer
 	METHOD aroundChunk (Lnet/minecraft/world/level/ChunkPos;III)Ljava/util/stream/Stream;
 		ARG 0 chunkPos
-		ARG 1 x
-		ARG 2 y
-		ARG 3 z
+		ARG 1 radius
+		ARG 2 minY
+		ARG 3 maxY
 	METHOD asLong (III)J
 		ARG 0 x
 		ARG 1 y

--- a/data/net/minecraft/world/entity/LivingEntity.mapping
+++ b/data/net/minecraft/world/entity/LivingEntity.mapping
@@ -1,5 +1,4 @@
 CLASS net/minecraft/world/entity/LivingEntity
-	COMMENT @return null or the {@linkplain LivingEntity} it was ignited by
 	FIELD lastHurt F
 		COMMENT Damage taken in the last hit. Mobs are resistant to damage less than this for a short time after taking damage.
 	FIELD lastHurtMobTimestamp I

--- a/data/net/minecraft/world/item/component/Consumable.mapping
+++ b/data/net/minecraft/world/item/component/Consumable.mapping
@@ -23,7 +23,7 @@ CLASS net/minecraft/world/item/component/Consumable
 		METHOD animation (Lnet/minecraft/world/item/ItemUseAnimation;)Lnet/minecraft/world/item/component/Consumable$Builder;
 			ARG 1 animation
 		METHOD consumeSeconds (F)Lnet/minecraft/world/item/component/Consumable$Builder;
-			ARG 1 consumeSounds
+			ARG 1 consumeSeconds
 		METHOD hasConsumeParticles (Z)Lnet/minecraft/world/item/component/Consumable$Builder;
 			ARG 1 hasConsumeParticles
 		METHOD onConsume (Lnet/minecraft/world/item/consume_effects/ConsumeEffect;)Lnet/minecraft/world/item/component/Consumable$Builder;

--- a/data/net/minecraft/world/level/block/BaseEntityBlock.mapping
+++ b/data/net/minecraft/world/level/block/BaseEntityBlock.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/world/level/block/BaseEntityBlock
 	METHOD createTickerHelper (Lnet/minecraft/world/level/block/entity/BlockEntityType;Lnet/minecraft/world/level/block/entity/BlockEntityType;Lnet/minecraft/world/level/block/entity/BlockEntityTicker;)Lnet/minecraft/world/level/block/entity/BlockEntityTicker;
-		ARG 0 serverType
-		ARG 1 clientType
+		ARG 0 actualType
+		ARG 1 expectedType
 		ARG 2 ticker
 	METHOD getMenuProvider (Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/MenuProvider;
 		ARG 1 state

--- a/data/net/minecraft/world/level/block/state/StateHolder.mapping
+++ b/data/net/minecraft/world/level/block/state/StateHolder.mapping
@@ -4,8 +4,8 @@ CLASS net/minecraft/world/level/block/state/StateHolder
 		ARG 2 values
 		ARG 3 propertiesCodec
 	METHOD codec (Lcom/mojang/serialization/Codec;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;
-		ARG 0 propertyMap
-		ARG 1 holderFunction
+		ARG 0 ownerCodec
+		ARG 1 defaultStateGetter
 	METHOD cycle (Lnet/minecraft/world/level/block/state/properties/Property;)Ljava/lang/Object;
 		ARG 1 property
 	METHOD equals (Ljava/lang/Object;)Z


### PR DESCRIPTION
This PR fixes various incorrect parameter mappings and removes a dangling doc comment:
- `NativeImage#copyRect()` copies to the provided `NativeImage`, not from it
- The parameter names of `ItemModelUtils.override()` are flipped
- The third parameter of `AbstractWidget#renderScrollingString()` specifies the horizontal padding to be subtracted from the widget's width on either side, not the width itself
- The parameter of `GuiRenderer#draw()` is specifically fog data, the existing name is effectively useless
- The `fog` parameter of `GuiRenderer#executeDrawRange()` is adjusted to match the parameter of `GuiRenderer#draw()`
- The second parameter of `BlockModelDefinition#instantiate()` and `BlockModelDefinition.SimpleModelSelectors#instantiate()` is a supplier of the definition's source file (file name and pack ID) for debugging
- The last three parameters of `SectionPos.aroundChunk()` provide the horizontal radius and the min and max Y coordinate
- `LivingEntity` has a dangling class-level doc comment
- `Consumable.Builder#consumeSeconds()` sets the `consumeSeconds`, not the `consumeSounds`
- The two `BlockEntityType` parameters of `BaseEntityBlock.createTickerHelper()` have nothing to do with server or client, they specify the actual type found in the world as provided by `EntityBlock#getTicker()` and the expected type as provided by the caller
- `StateHolder.codec()` takes the owner's lookup codec (i.e. block/fluid registry codec) and a function to look up the default state to which the decoded properties are then appended