### PR TITLE
Fix parameter reorder of `Mth.clampedLerp`

### DIFF
--- a/data/net/minecraft/util/Mth.mapping
+++ b/data/net/minecraft/util/Mth.mapping
@@ -86,20 +86,20 @@ CLASS net/minecraft/util/Mth
 		ARG 4 max
 	METHOD clampedLerp (DDD)D
 		COMMENT Method for linear interpolation of doubles.
-		ARG 0 start
+		ARG 0 delta
+			COMMENT A value between 0 and 1 that indicates the percentage of the lerp. (0 will give the start value and 1 will give the end value) If the value is not between 0 and 1, it is clamped.
+		ARG 2 start
+			COMMENT Start value for the lerp.
+		ARG 4 end
+			COMMENT End value for the lerp.
+	METHOD clampedLerp (FFF)F
+		COMMENT Method for linear interpolation of floats.
+		ARG 0 delta
+			COMMENT A value between 0 and 1 that indicates the percentage of the lerp. (0 will give the start value and 1 will give the end value) If the value is not between 0 and 1, it is clamped.
+		ARG 1 start
 			COMMENT Start value for the lerp.
 		ARG 2 end
 			COMMENT End value for the lerp.
-		ARG 4 delta
-			COMMENT A value between 0 and 1 that indicates the percentage of the lerp. (0 will give the start value and 1 will give the end value) If the value is not between 0 and 1, it is clamped.
-	METHOD clampedLerp (FFF)F
-		COMMENT Method for linear interpolation of floats.
-		ARG 0 start
-			COMMENT Start value for the lerp.
-		ARG 1 end
-			COMMENT End value for the lerp.
-		ARG 2 delta
-			COMMENT A value between 0 and 1 that indicates the percentage of the lerp. (0 will give the start value and 1 will give the end value) If the value is not between 0 and 1, it is clamped.
 	METHOD clampedMap (DDDDD)D
 		ARG 0 input
 		ARG 2 inputMin


### PR DESCRIPTION
Parameters of `Mth.clampedLerp` (including 2 overloads) has been reordered since 1.21.11, as described in [the NeoForge Primer](https://github.com/neoforged/.github/blob/main/primers/1.21.11/index.md#specific-logic-changes) and verified through the decompiled source code.

The original order: (start, end, delta)

Now (1.21.11): (delta, start, end)

Behavior of this function remains unchanged.